### PR TITLE
Update keyfactor-go-client-sdk Import Statements

### DIFF
--- a/cmd/export.go
+++ b/cmd/export.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	keyfactor_command_client_api "github.com/Keyfactor/keyfactor-go-client-sdk"
+	"github.com/Keyfactor/keyfactor-go-client-sdk/api/keyfactor"
 	"github.com/Keyfactor/keyfactor-go-client/api"
 	"github.com/spf13/cobra"
 	"log"
@@ -26,21 +26,21 @@ var fSecurityRoles bool
 var fAll bool
 
 type exportModelsReport struct {
-	Id                      *int32                                                `json:"-"`
-	Scheduled               *int32                                                `json:"Scheduled,omitempty"`
-	DisplayName             *string                                               `json:"DisplayName,omitempty"`
-	Description             *string                                               `json:"Description,omitempty"`
-	ReportPath              *string                                               `json:"ReportPath,omitempty"`
-	VersionNumber           *string                                               `json:"VersionNumber,omitempty"`
-	Categories              *string                                               `json:"Categories,omitempty"`
-	ShortName               *string                                               `json:"ShortName,omitempty"`
-	InNavigator             *bool                                                 `json:"InNavigator,omitempty"`
-	Favorite                *bool                                                 `json:"Favorite,omitempty"`
-	RemoveDuplicates        *bool                                                 `json:"RemoveDuplicates,omitempty"`
-	UsesCollection          *bool                                                 `json:"UsesCollection,omitempty"`
-	ReportParameter         []keyfactor_command_client_api.ModelsReportParameters `json:"ReportParameter,omitempty"`
-	Schedules               []keyfactor_command_client_api.ModelsReportSchedule   `json:"Schedules,omitempty"`
-	AcceptedScheduleFormats []string                                              `json:"AcceptedScheduleFormats,omitempty"`
+	Id                      *int32                             `json:"-"`
+	Scheduled               *int32                             `json:"Scheduled,omitempty"`
+	DisplayName             *string                            `json:"DisplayName,omitempty"`
+	Description             *string                            `json:"Description,omitempty"`
+	ReportPath              *string                            `json:"ReportPath,omitempty"`
+	VersionNumber           *string                            `json:"VersionNumber,omitempty"`
+	Categories              *string                            `json:"Categories,omitempty"`
+	ShortName               *string                            `json:"ShortName,omitempty"`
+	InNavigator             *bool                              `json:"InNavigator,omitempty"`
+	Favorite                *bool                              `json:"Favorite,omitempty"`
+	RemoveDuplicates        *bool                              `json:"RemoveDuplicates,omitempty"`
+	UsesCollection          *bool                              `json:"UsesCollection,omitempty"`
+	ReportParameter         []keyfactor.ModelsReportParameters `json:"ReportParameter,omitempty"`
+	Schedules               []keyfactor.ModelsReportSchedule   `json:"Schedules,omitempty"`
+	AcceptedScheduleFormats []string                           `json:"AcceptedScheduleFormats,omitempty"`
 }
 
 type exportKeyfactorApiModelsWorkflowsDefinitionCreateRequest struct {
@@ -57,17 +57,17 @@ type exportKeyfactorApiModelsWorkflowsDefinitionCreateRequest struct {
 }
 
 type outJson struct {
-	Collections         []keyfactor_command_client_api.KeyfactorApiModelsCertificateCollectionsCertificateCollectionCreateRequest `json:"Collections"`
-	MetadataFields      []keyfactor_command_client_api.KeyfactorApiModelsMetadataFieldMetadataFieldCreateRequest                  `json:"MetadataFields"`
-	ExpirationAlerts    []keyfactor_command_client_api.KeyfactorApiModelsAlertsExpirationExpirationAlertCreationRequest           `json:"ExpirationAlerts"`
-	IssuedCertAlerts    []keyfactor_command_client_api.KeyfactorApiModelsAlertsIssuedIssuedAlertCreationRequest                   `json:"IssuedCertAlerts"`
-	DeniedCertAlerts    []keyfactor_command_client_api.KeyfactorApiModelsAlertsDeniedDeniedAlertCreationRequest                   `json:"DeniedCertAlerts"`
-	PendingCertAlerts   []keyfactor_command_client_api.KeyfactorApiModelsAlertsPendingPendingAlertCreationRequest                 `json:"PendingCertAlerts"`
-	Networks            []keyfactor_command_client_api.KeyfactorApiModelsSslCreateNetworkRequest                                  `json:"Networks"`
-	WorkflowDefinitions []exportKeyfactorApiModelsWorkflowsDefinitionCreateRequest                                                `json:"WorkflowDefinitions"`
-	BuiltInReports      []exportModelsReport                                                                                      `json:"BuiltInReports"`
-	CustomReports       []keyfactor_command_client_api.ModelsCustomReportCreationRequest                                          `json:"CustomReports"`
-	SecurityRoles       []api.CreateSecurityRoleArg                                                                               `json:"SecurityRoles"`
+	Collections         []keyfactor.KeyfactorApiModelsCertificateCollectionsCertificateCollectionCreateRequest `json:"Collections"`
+	MetadataFields      []keyfactor.KeyfactorApiModelsMetadataFieldMetadataFieldCreateRequest                  `json:"MetadataFields"`
+	ExpirationAlerts    []keyfactor.KeyfactorApiModelsAlertsExpirationExpirationAlertCreationRequest           `json:"ExpirationAlerts"`
+	IssuedCertAlerts    []keyfactor.KeyfactorApiModelsAlertsIssuedIssuedAlertCreationRequest                   `json:"IssuedCertAlerts"`
+	DeniedCertAlerts    []keyfactor.KeyfactorApiModelsAlertsDeniedDeniedAlertCreationRequest                   `json:"DeniedCertAlerts"`
+	PendingCertAlerts   []keyfactor.KeyfactorApiModelsAlertsPendingPendingAlertCreationRequest                 `json:"PendingCertAlerts"`
+	Networks            []keyfactor.KeyfactorApiModelsSslCreateNetworkRequest                                  `json:"Networks"`
+	WorkflowDefinitions []exportKeyfactorApiModelsWorkflowsDefinitionCreateRequest                             `json:"WorkflowDefinitions"`
+	BuiltInReports      []exportModelsReport                                                                   `json:"BuiltInReports"`
+	CustomReports       []keyfactor.ModelsCustomReportCreationRequest                                          `json:"CustomReports"`
+	SecurityRoles       []api.CreateSecurityRoleArg                                                            `json:"SecurityRoles"`
 }
 
 func exportToJSON(out outJson, exportPath string) {
@@ -93,16 +93,16 @@ var exportCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		// initialize each entry as an empty list in the event it is not requested by the flags
 		out := outJson{
-			Collections:         []keyfactor_command_client_api.KeyfactorApiModelsCertificateCollectionsCertificateCollectionCreateRequest{},
-			MetadataFields:      []keyfactor_command_client_api.KeyfactorApiModelsMetadataFieldMetadataFieldCreateRequest{},
-			ExpirationAlerts:    []keyfactor_command_client_api.KeyfactorApiModelsAlertsExpirationExpirationAlertCreationRequest{},
-			IssuedCertAlerts:    []keyfactor_command_client_api.KeyfactorApiModelsAlertsIssuedIssuedAlertCreationRequest{},
-			DeniedCertAlerts:    []keyfactor_command_client_api.KeyfactorApiModelsAlertsDeniedDeniedAlertCreationRequest{},
-			PendingCertAlerts:   []keyfactor_command_client_api.KeyfactorApiModelsAlertsPendingPendingAlertCreationRequest{},
-			Networks:            []keyfactor_command_client_api.KeyfactorApiModelsSslCreateNetworkRequest{},
+			Collections:         []keyfactor.KeyfactorApiModelsCertificateCollectionsCertificateCollectionCreateRequest{},
+			MetadataFields:      []keyfactor.KeyfactorApiModelsMetadataFieldMetadataFieldCreateRequest{},
+			ExpirationAlerts:    []keyfactor.KeyfactorApiModelsAlertsExpirationExpirationAlertCreationRequest{},
+			IssuedCertAlerts:    []keyfactor.KeyfactorApiModelsAlertsIssuedIssuedAlertCreationRequest{},
+			DeniedCertAlerts:    []keyfactor.KeyfactorApiModelsAlertsDeniedDeniedAlertCreationRequest{},
+			PendingCertAlerts:   []keyfactor.KeyfactorApiModelsAlertsPendingPendingAlertCreationRequest{},
+			Networks:            []keyfactor.KeyfactorApiModelsSslCreateNetworkRequest{},
 			WorkflowDefinitions: []exportKeyfactorApiModelsWorkflowsDefinitionCreateRequest{},
 			BuiltInReports:      []exportModelsReport{},
-			CustomReports:       []keyfactor_command_client_api.ModelsCustomReportCreationRequest{},
+			CustomReports:       []keyfactor.ModelsCustomReportCreationRequest{},
 			SecurityRoles:       []api.CreateSecurityRoleArg{},
 		}
 		exportPath := cmd.Flag("file").Value.String()
@@ -153,16 +153,16 @@ var exportCmd = &cobra.Command{
 	},
 }
 
-func getCollections() []keyfactor_command_client_api.KeyfactorApiModelsCertificateCollectionsCertificateCollectionCreateRequest {
+func getCollections() []keyfactor.KeyfactorApiModelsCertificateCollectionsCertificateCollectionCreateRequest {
 	kfClient := initGenClient()
 	collections, _, reqErr := kfClient.CertificateCollectionApi.CertificateCollectionGetCollections(context.Background()).XKeyfactorRequestedWith(xKeyfactorRequestedWith).XKeyfactorApiVersion(xKeyfactorApiVersion).Execute()
 	if reqErr != nil {
 		fmt.Printf("%s Error! Unable to get collections %s%s\n", colorRed, reqErr, colorWhite)
 	}
-	var lCollectionReq []keyfactor_command_client_api.KeyfactorApiModelsCertificateCollectionsCertificateCollectionCreateRequest
+	var lCollectionReq []keyfactor.KeyfactorApiModelsCertificateCollectionsCertificateCollectionCreateRequest
 	for _, collection := range collections {
 		cJson, _ := json.Marshal(collection)
-		var collectionReq keyfactor_command_client_api.KeyfactorApiModelsCertificateCollectionsCertificateCollectionCreateRequest
+		var collectionReq keyfactor.KeyfactorApiModelsCertificateCollectionsCertificateCollectionCreateRequest
 		jErr := json.Unmarshal(cJson, &collectionReq)
 		if jErr != nil {
 			fmt.Printf("Error: %s\n", jErr)
@@ -175,16 +175,16 @@ func getCollections() []keyfactor_command_client_api.KeyfactorApiModelsCertifica
 	return lCollectionReq
 }
 
-func getMetadata() []keyfactor_command_client_api.KeyfactorApiModelsMetadataFieldMetadataFieldCreateRequest {
+func getMetadata() []keyfactor.KeyfactorApiModelsMetadataFieldMetadataFieldCreateRequest {
 	kfClient := initGenClient()
 	metadata, _, reqErr := kfClient.MetadataFieldApi.MetadataFieldGetAllMetadataFields(context.Background()).XKeyfactorRequestedWith(xKeyfactorRequestedWith).XKeyfactorApiVersion(xKeyfactorApiVersion).Execute()
 	if reqErr != nil {
 		fmt.Printf("%s Error! Unable to get metadata %s%s\n", colorRed, reqErr, colorWhite)
 	}
-	var lMetadataReq []keyfactor_command_client_api.KeyfactorApiModelsMetadataFieldMetadataFieldCreateRequest
+	var lMetadataReq []keyfactor.KeyfactorApiModelsMetadataFieldMetadataFieldCreateRequest
 	for _, metadataItem := range metadata {
 		mJson, _ := json.Marshal(metadataItem)
-		var metadataReq keyfactor_command_client_api.KeyfactorApiModelsMetadataFieldMetadataFieldCreateRequest
+		var metadataReq keyfactor.KeyfactorApiModelsMetadataFieldMetadataFieldCreateRequest
 		jErr := json.Unmarshal(mJson, &metadataReq)
 		if jErr != nil {
 			fmt.Printf("Error: %s\n", jErr)
@@ -196,16 +196,16 @@ func getMetadata() []keyfactor_command_client_api.KeyfactorApiModelsMetadataFiel
 	return lMetadataReq
 }
 
-func getExpirationAlerts() []keyfactor_command_client_api.KeyfactorApiModelsAlertsExpirationExpirationAlertCreationRequest {
+func getExpirationAlerts() []keyfactor.KeyfactorApiModelsAlertsExpirationExpirationAlertCreationRequest {
 	kfClient := initGenClient()
 	alerts, _, reqErr := kfClient.ExpirationAlertApi.ExpirationAlertGetExpirationAlerts(context.Background()).XKeyfactorRequestedWith(xKeyfactorRequestedWith).XKeyfactorApiVersion(xKeyfactorApiVersion).Execute()
 	if reqErr != nil {
 		fmt.Printf("%s Error! Unable to get expiration alerts %s%s\n", colorRed, reqErr, colorWhite)
 	}
-	var lAlertReq []keyfactor_command_client_api.KeyfactorApiModelsAlertsExpirationExpirationAlertCreationRequest
+	var lAlertReq []keyfactor.KeyfactorApiModelsAlertsExpirationExpirationAlertCreationRequest
 	for _, alert := range alerts {
 		mJson, _ := json.Marshal(alert)
-		var alertReq keyfactor_command_client_api.KeyfactorApiModelsAlertsExpirationExpirationAlertCreationRequest
+		var alertReq keyfactor.KeyfactorApiModelsAlertsExpirationExpirationAlertCreationRequest
 		jErr := json.Unmarshal(mJson, &alertReq)
 		if jErr != nil {
 			fmt.Printf("Error: %s\n", jErr)
@@ -216,16 +216,16 @@ func getExpirationAlerts() []keyfactor_command_client_api.KeyfactorApiModelsAler
 	return lAlertReq
 }
 
-func getIssuedAlerts() []keyfactor_command_client_api.KeyfactorApiModelsAlertsIssuedIssuedAlertCreationRequest {
+func getIssuedAlerts() []keyfactor.KeyfactorApiModelsAlertsIssuedIssuedAlertCreationRequest {
 	kfClient := initGenClient()
 	alerts, _, reqErr := kfClient.IssuedAlertApi.IssuedAlertGetIssuedAlerts(context.Background()).XKeyfactorRequestedWith(xKeyfactorRequestedWith).XKeyfactorApiVersion(xKeyfactorApiVersion).Execute()
 	if reqErr != nil {
 		fmt.Printf("%s Error! Unable to get issued cert alerts %s%s\n", colorRed, reqErr, colorWhite)
 	}
-	var lAlertReq []keyfactor_command_client_api.KeyfactorApiModelsAlertsIssuedIssuedAlertCreationRequest
+	var lAlertReq []keyfactor.KeyfactorApiModelsAlertsIssuedIssuedAlertCreationRequest
 	for _, alert := range alerts {
 		mJson, _ := json.Marshal(alert)
-		var alertReq keyfactor_command_client_api.KeyfactorApiModelsAlertsIssuedIssuedAlertCreationRequest
+		var alertReq keyfactor.KeyfactorApiModelsAlertsIssuedIssuedAlertCreationRequest
 		jErr := json.Unmarshal(mJson, &alertReq)
 		if jErr != nil {
 			fmt.Printf("Error: %s\n", jErr)
@@ -237,16 +237,16 @@ func getIssuedAlerts() []keyfactor_command_client_api.KeyfactorApiModelsAlertsIs
 	return lAlertReq
 }
 
-func getDeniedAlerts() []keyfactor_command_client_api.KeyfactorApiModelsAlertsDeniedDeniedAlertCreationRequest {
+func getDeniedAlerts() []keyfactor.KeyfactorApiModelsAlertsDeniedDeniedAlertCreationRequest {
 	kfClient := initGenClient()
 	alerts, _, reqErr := kfClient.DeniedAlertApi.DeniedAlertGetDeniedAlerts(context.Background()).XKeyfactorRequestedWith(xKeyfactorRequestedWith).XKeyfactorApiVersion(xKeyfactorApiVersion).Execute()
 	if reqErr != nil {
 		fmt.Printf("%s Error! Unable to get denied cert alerts %s%s\n", colorRed, reqErr, colorWhite)
 	}
-	var lAlertReq []keyfactor_command_client_api.KeyfactorApiModelsAlertsDeniedDeniedAlertCreationRequest
+	var lAlertReq []keyfactor.KeyfactorApiModelsAlertsDeniedDeniedAlertCreationRequest
 	for _, alert := range alerts {
 		mJson, _ := json.Marshal(alert)
-		var alertReq keyfactor_command_client_api.KeyfactorApiModelsAlertsDeniedDeniedAlertCreationRequest
+		var alertReq keyfactor.KeyfactorApiModelsAlertsDeniedDeniedAlertCreationRequest
 		jErr := json.Unmarshal(mJson, &alertReq)
 		if jErr != nil {
 			fmt.Printf("Error: %s\n", jErr)
@@ -258,16 +258,16 @@ func getDeniedAlerts() []keyfactor_command_client_api.KeyfactorApiModelsAlertsDe
 	return lAlertReq
 }
 
-func getPendingAlerts() []keyfactor_command_client_api.KeyfactorApiModelsAlertsPendingPendingAlertCreationRequest {
+func getPendingAlerts() []keyfactor.KeyfactorApiModelsAlertsPendingPendingAlertCreationRequest {
 	kfClient := initGenClient()
 	alerts, _, reqErr := kfClient.PendingAlertApi.PendingAlertGetPendingAlerts(context.Background()).XKeyfactorRequestedWith(xKeyfactorRequestedWith).XKeyfactorApiVersion(xKeyfactorApiVersion).Execute()
 	if reqErr != nil {
 		fmt.Printf("%s Error! Unable to get pending cert alerts %s%s\n", colorRed, reqErr, colorWhite)
 	}
-	var lAlertReq []keyfactor_command_client_api.KeyfactorApiModelsAlertsPendingPendingAlertCreationRequest
+	var lAlertReq []keyfactor.KeyfactorApiModelsAlertsPendingPendingAlertCreationRequest
 	for _, alert := range alerts {
 		mJson, _ := json.Marshal(alert)
-		var alertReq keyfactor_command_client_api.KeyfactorApiModelsAlertsPendingPendingAlertCreationRequest
+		var alertReq keyfactor.KeyfactorApiModelsAlertsPendingPendingAlertCreationRequest
 		jErr := json.Unmarshal(mJson, &alertReq)
 		if jErr != nil {
 			fmt.Printf("Error: %s\n", jErr)
@@ -279,16 +279,16 @@ func getPendingAlerts() []keyfactor_command_client_api.KeyfactorApiModelsAlertsP
 	return lAlertReq
 }
 
-func getSslNetworks() []keyfactor_command_client_api.KeyfactorApiModelsSslCreateNetworkRequest {
+func getSslNetworks() []keyfactor.KeyfactorApiModelsSslCreateNetworkRequest {
 	kfClient := initGenClient()
 	networks, _, reqErr := kfClient.SslApi.SslGetNetworks(context.Background()).XKeyfactorRequestedWith(xKeyfactorRequestedWith).XKeyfactorApiVersion(xKeyfactorApiVersion).Execute()
 	if reqErr != nil {
 		fmt.Printf("%s Error! Unable to get SSL networks %s%s\n", colorRed, reqErr, colorWhite)
 	}
-	var lNetworkReq []keyfactor_command_client_api.KeyfactorApiModelsSslCreateNetworkRequest
+	var lNetworkReq []keyfactor.KeyfactorApiModelsSslCreateNetworkRequest
 	for _, network := range networks {
 		mJson, _ := json.Marshal(network)
-		var networkReq keyfactor_command_client_api.KeyfactorApiModelsSslCreateNetworkRequest
+		var networkReq keyfactor.KeyfactorApiModelsSslCreateNetworkRequest
 		jErr := json.Unmarshal(mJson, &networkReq)
 		if jErr != nil {
 			fmt.Printf("Error: %s\n", jErr)
@@ -326,7 +326,7 @@ func getWorkflowDefinitions() []exportKeyfactorApiModelsWorkflowsDefinitionCreat
 	return lWorkflowReq
 }
 
-func getReports() ([]exportModelsReport, []keyfactor_command_client_api.ModelsCustomReportCreationRequest) {
+func getReports() ([]exportModelsReport, []keyfactor.ModelsCustomReportCreationRequest) {
 	kfClient := initGenClient()
 	//Gets all built-in reports
 	bReports, _, bErr := kfClient.ReportsApi.ReportsQueryReports(context.Background()).XKeyfactorRequestedWith(xKeyfactorRequestedWith).XKeyfactorApiVersion(xKeyfactorApiVersion).Execute()
@@ -350,10 +350,10 @@ func getReports() ([]exportModelsReport, []keyfactor_command_client_api.ModelsCu
 	if cErr != nil {
 		fmt.Printf("%s Error! Unable to get custom reports %s%s\n", colorRed, cErr, colorWhite)
 	}
-	var lcReportReq []keyfactor_command_client_api.ModelsCustomReportCreationRequest
+	var lcReportReq []keyfactor.ModelsCustomReportCreationRequest
 	for _, cReport := range cReports {
 		mJson, _ := json.Marshal(cReport)
-		var cReportReq keyfactor_command_client_api.ModelsCustomReportCreationRequest
+		var cReportReq keyfactor.ModelsCustomReportCreationRequest
 		jErr := json.Unmarshal(mJson, &cReportReq)
 		if jErr != nil {
 			fmt.Printf("Error: %s\n", jErr)

--- a/cmd/export.go
+++ b/cmd/export.go
@@ -387,7 +387,7 @@ func getRoles() []api.CreateSecurityRoleArg {
 func init() {
 	RootCmd.AddCommand(exportCmd)
 
-	exportCmd.Flags().StringVarP(&exportPath, "file", "f", "", "export JSON to a specified filepath")
+	exportCmd.Flags().StringVarP(&exportPath, "file", "f", "", "path to JSON output file with exported data")
 	exportCmd.MarkFlagRequired("file")
 
 	exportCmd.Flags().BoolVarP(&fAll, "all", "a", false, "export all exportable data to JSON file")

--- a/cmd/import.go
+++ b/cmd/import.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	keyfactor_command_client_api "github.com/Keyfactor/keyfactor-go-client-sdk"
+	"github.com/Keyfactor/keyfactor-go-client-sdk/api/keyfactor"
 	"github.com/Keyfactor/keyfactor-go-client/api"
 	"github.com/spf13/cobra"
 	"io"
@@ -91,7 +91,7 @@ var importCmd = &cobra.Command{
 	},
 }
 
-func importCollections(collections []keyfactor_command_client_api.KeyfactorApiModelsCertificateCollectionsCertificateCollectionCreateRequest, kfClient *keyfactor_command_client_api.APIClient) {
+func importCollections(collections []keyfactor.KeyfactorApiModelsCertificateCollectionsCertificateCollectionCreateRequest, kfClient *keyfactor.APIClient) {
 	for _, collection := range collections {
 		_, httpResp, reqErr := kfClient.CertificateCollectionApi.CertificateCollectionCreateCollection(context.Background()).XKeyfactorRequestedWith(xKeyfactorRequestedWith).
 			Request(collection).XKeyfactorApiVersion(xKeyfactorApiVersion).Execute()
@@ -105,7 +105,7 @@ func importCollections(collections []keyfactor_command_client_api.KeyfactorApiMo
 	}
 }
 
-func importMetadataFields(metadataFields []keyfactor_command_client_api.KeyfactorApiModelsMetadataFieldMetadataFieldCreateRequest, kfClient *keyfactor_command_client_api.APIClient) {
+func importMetadataFields(metadataFields []keyfactor.KeyfactorApiModelsMetadataFieldMetadataFieldCreateRequest, kfClient *keyfactor.APIClient) {
 	for _, metadata := range metadataFields {
 		_, httpResp, reqErr := kfClient.MetadataFieldApi.MetadataFieldCreateMetadataField(context.Background()).
 			XKeyfactorRequestedWith(xKeyfactorRequestedWith).MetadataFieldType(metadata).
@@ -119,7 +119,7 @@ func importMetadataFields(metadataFields []keyfactor_command_client_api.Keyfacto
 	}
 }
 
-func importIssuedCertAlerts(alerts []keyfactor_command_client_api.KeyfactorApiModelsAlertsIssuedIssuedAlertCreationRequest, kfClient *keyfactor_command_client_api.APIClient) {
+func importIssuedCertAlerts(alerts []keyfactor.KeyfactorApiModelsAlertsIssuedIssuedAlertCreationRequest, kfClient *keyfactor.APIClient) {
 	for _, alert := range alerts {
 		_, httpResp, reqErr := kfClient.IssuedAlertApi.IssuedAlertAddIssuedAlert(context.Background()).XKeyfactorRequestedWith(xKeyfactorRequestedWith).Req(alert).XKeyfactorApiVersion(xKeyfactorApiVersion).Execute()
 		name, _ := json.Marshal(alert.DisplayName)
@@ -131,7 +131,7 @@ func importIssuedCertAlerts(alerts []keyfactor_command_client_api.KeyfactorApiMo
 	}
 }
 
-func importDeniedCertAlerts(alerts []keyfactor_command_client_api.KeyfactorApiModelsAlertsDeniedDeniedAlertCreationRequest, kfClient *keyfactor_command_client_api.APIClient) {
+func importDeniedCertAlerts(alerts []keyfactor.KeyfactorApiModelsAlertsDeniedDeniedAlertCreationRequest, kfClient *keyfactor.APIClient) {
 	for _, alert := range alerts {
 		_, httpResp, reqErr := kfClient.DeniedAlertApi.DeniedAlertAddDeniedAlert(context.Background()).XKeyfactorRequestedWith(xKeyfactorRequestedWith).Req(alert).XKeyfactorApiVersion(xKeyfactorApiVersion).Execute()
 		name, _ := json.Marshal(alert.DisplayName)
@@ -143,7 +143,7 @@ func importDeniedCertAlerts(alerts []keyfactor_command_client_api.KeyfactorApiMo
 	}
 }
 
-func importPendingCertAlerts(alerts []keyfactor_command_client_api.KeyfactorApiModelsAlertsPendingPendingAlertCreationRequest, kfClient *keyfactor_command_client_api.APIClient) {
+func importPendingCertAlerts(alerts []keyfactor.KeyfactorApiModelsAlertsPendingPendingAlertCreationRequest, kfClient *keyfactor.APIClient) {
 	for _, alert := range alerts {
 		_, httpResp, reqErr := kfClient.PendingAlertApi.PendingAlertAddPendingAlert(context.Background()).XKeyfactorRequestedWith(xKeyfactorRequestedWith).Req(alert).XKeyfactorApiVersion(xKeyfactorApiVersion).Execute()
 		name, _ := json.Marshal(alert.DisplayName)
@@ -155,7 +155,7 @@ func importPendingCertAlerts(alerts []keyfactor_command_client_api.KeyfactorApiM
 	}
 }
 
-func importNetworks(networks []keyfactor_command_client_api.KeyfactorApiModelsSslCreateNetworkRequest, kfClient *keyfactor_command_client_api.APIClient) {
+func importNetworks(networks []keyfactor.KeyfactorApiModelsSslCreateNetworkRequest, kfClient *keyfactor.APIClient) {
 	for _, network := range networks {
 		_, httpResp, reqErr := kfClient.SslApi.SslCreateNetwork(context.Background()).XKeyfactorRequestedWith(xKeyfactorRequestedWith).Network(network).XKeyfactorApiVersion(xKeyfactorApiVersion).Execute()
 		name, _ := json.Marshal(network.Name)
@@ -168,7 +168,7 @@ func importNetworks(networks []keyfactor_command_client_api.KeyfactorApiModelsSs
 }
 
 // identify matching templates between instances by name, then return the template Id of the matching template in the import instance
-func findMatchingTemplates(exportedWorkflowDef exportKeyfactorApiModelsWorkflowsDefinitionCreateRequest, kfClient *keyfactor_command_client_api.APIClient) *string {
+func findMatchingTemplates(exportedWorkflowDef exportKeyfactorApiModelsWorkflowsDefinitionCreateRequest, kfClient *keyfactor.APIClient) *string {
 	importInstanceTemplates, _, _ := kfClient.TemplateApi.TemplateGetTemplates(context.Background()).XKeyfactorRequestedWith(xKeyfactorRequestedWith).XKeyfactorApiVersion(xKeyfactorApiVersion).Execute()
 	for _, template := range importInstanceTemplates {
 		importInstTempNameJson, _ := json.Marshal(template.TemplateName)
@@ -182,10 +182,10 @@ func findMatchingTemplates(exportedWorkflowDef exportKeyfactorApiModelsWorkflows
 	return nil
 }
 
-func importWorkflowDefinitions(workflowDefs []exportKeyfactorApiModelsWorkflowsDefinitionCreateRequest, kfClient *keyfactor_command_client_api.APIClient) {
+func importWorkflowDefinitions(workflowDefs []exportKeyfactorApiModelsWorkflowsDefinitionCreateRequest, kfClient *keyfactor.APIClient) {
 	for _, workflowDef := range workflowDefs {
 		wJson, _ := json.Marshal(workflowDef)
-		var workflowDefReq keyfactor_command_client_api.KeyfactorApiModelsWorkflowsDefinitionCreateRequest
+		var workflowDefReq keyfactor.KeyfactorApiModelsWorkflowsDefinitionCreateRequest
 		jErr := json.Unmarshal(wJson, &workflowDefReq)
 		if jErr != nil {
 			fmt.Printf("Error: %s\n", jErr)
@@ -206,7 +206,7 @@ func importWorkflowDefinitions(workflowDefs []exportKeyfactorApiModelsWorkflowsD
 }
 
 // check for built-in report discrepancies between instances, return the report id of reports that need to be updated in import instance
-func checkBuiltInReportDiffs(exportedReport exportModelsReport, kfClient *keyfactor_command_client_api.APIClient) *int32 {
+func checkBuiltInReportDiffs(exportedReport exportModelsReport, kfClient *keyfactor.APIClient) *int32 {
 	importInstanceReports, _, _ := kfClient.ReportsApi.ReportsQueryReports(context.Background()).XKeyfactorRequestedWith(xKeyfactorRequestedWith).XKeyfactorApiVersion(xKeyfactorApiVersion).Execute()
 	//check if built in report was modified from default in exported instance; if modified, update built-in report in new instance
 	for _, report := range importInstanceReports {
@@ -232,12 +232,12 @@ func checkBuiltInReportDiffs(exportedReport exportModelsReport, kfClient *keyfac
 }
 
 // only imports built in reports where UsesCollections is false
-func importBuiltInReports(reports []exportModelsReport, kfClient *keyfactor_command_client_api.APIClient) {
+func importBuiltInReports(reports []exportModelsReport, kfClient *keyfactor.APIClient) {
 	for _, report := range reports {
 		newReportId := checkBuiltInReportDiffs(report, kfClient)
 		if newReportId != nil {
 			rJson, _ := json.Marshal(report)
-			var reportReq keyfactor_command_client_api.ModelsReportRequestModel
+			var reportReq keyfactor.ModelsReportRequestModel
 			jErr := json.Unmarshal(rJson, &reportReq)
 			if jErr != nil {
 				fmt.Printf("Error: %s\n", jErr)
@@ -255,7 +255,7 @@ func importBuiltInReports(reports []exportModelsReport, kfClient *keyfactor_comm
 	}
 }
 
-func importCustomReports(reports []keyfactor_command_client_api.ModelsCustomReportCreationRequest, kfClient *keyfactor_command_client_api.APIClient) {
+func importCustomReports(reports []keyfactor.ModelsCustomReportCreationRequest, kfClient *keyfactor.APIClient) {
 	for _, report := range reports {
 		_, httpResp, reqErr := kfClient.ReportsApi.ReportsCreateCustomReport(context.Background()).XKeyfactorRequestedWith(xKeyfactorRequestedWith).Request(report).XKeyfactorApiVersion(xKeyfactorApiVersion).Execute()
 		name, _ := json.Marshal(report.DisplayName)

--- a/cmd/import.go
+++ b/cmd/import.go
@@ -282,7 +282,7 @@ func importSecurityRoles(roles []api.CreateSecurityRoleArg, kfClient *api.Client
 func init() {
 	RootCmd.AddCommand(importCmd)
 
-	importCmd.Flags().StringVarP(&exportPath, "file", "f", "", "import JSON to a specified filepath")
+	importCmd.Flags().StringVarP(&exportPath, "file", "f", "", "path to JSON file containing exported data")
 	importCmd.MarkFlagRequired("file")
 
 	importCmd.Flags().BoolVarP(&fAll, "all", "a", false, "import all importable data to JSON file")
@@ -292,8 +292,6 @@ func init() {
 	importCmd.Flags().Lookup("collections").NoOptDefVal = "true"
 	importCmd.Flags().BoolVarP(&fMetadata, "metadata", "m", false, "import metadata to JSON file")
 	importCmd.Flags().Lookup("metadata").NoOptDefVal = "true"
-	importCmd.Flags().BoolVarP(&fExpirationAlerts, "expiration-alerts", "e", false, "import expiration cert alerts to JSON file")
-	importCmd.Flags().Lookup("expiration-alerts").NoOptDefVal = "true"
 	importCmd.Flags().BoolVarP(&fIssuedAlerts, "issued-alerts", "i", false, "import issued cert alerts to JSON file")
 	importCmd.Flags().Lookup("issued-alerts").NoOptDefVal = "true"
 	importCmd.Flags().BoolVarP(&fDeniedAlerts, "denied-alerts", "d", false, "import denied cert alerts to JSON file")

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -8,7 +8,7 @@ package cmd
 
 import (
 	"fmt"
-	keyfactor_command_client_api "github.com/Keyfactor/keyfactor-go-client-sdk"
+	"github.com/Keyfactor/keyfactor-go-client-sdk/api/keyfactor"
 	"github.com/Keyfactor/keyfactor-go-client/api"
 	"github.com/spf13/cobra"
 	"io"
@@ -56,9 +56,9 @@ func initClient() (*api.Client, error) {
 	return c, nil
 }
 
-func initGenClient() *keyfactor_command_client_api.APIClient {
-	configuration := keyfactor_command_client_api.NewConfiguration()
-	c := keyfactor_command_client_api.NewAPIClient(configuration)
+func initGenClient() *keyfactor.APIClient {
+	configuration := keyfactor.NewConfiguration()
+	c := keyfactor.NewAPIClient(configuration)
 	return c
 }
 

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.19
 
 require (
 	github.com/Jeffail/gabs/v2 v2.6.1
-	github.com/Keyfactor/keyfactor-go-client v1.3.2-0.20230328010103-e4fe507c6a5f
+	github.com/Keyfactor/keyfactor-go-client v1.3.2-0.20230328014202-a92b8603fc5f
 	github.com/spf13/cobra v1.6.1
 	golang.org/x/crypto v0.0.0-20220331220935-ae2d96664a29
 )
@@ -15,7 +15,6 @@ require (
 	github.com/inconshreveable/mousetrap v1.0.1 // indirect
 	github.com/russross/blackfriday/v2 v2.1.0 // indirect
 	github.com/spbsoluble/go-pkcs12 v0.3.1 // indirect
-	github.com/spbsoluble/keyfactor-go-client-sdk v1.0.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 	go.mozilla.org/pkcs7 v0.0.0-20210826202110-33d05740a352 // indirect
 	golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1 // indirect

--- a/go.mod
+++ b/go.mod
@@ -4,17 +4,18 @@ go 1.19
 
 require (
 	github.com/Jeffail/gabs/v2 v2.6.1
-	github.com/Keyfactor/keyfactor-go-client v1.4.0
+	github.com/Keyfactor/keyfactor-go-client v1.3.2-0.20230328010103-e4fe507c6a5f
 	github.com/spf13/cobra v1.6.1
 	golang.org/x/crypto v0.0.0-20220331220935-ae2d96664a29
 )
 
 require (
-	github.com/Keyfactor/keyfactor-go-client-sdk v0.0.0-20230207174129-9d99e523eb15 // indirect
+	github.com/Keyfactor/keyfactor-go-client-sdk v0.1.0 // indirect
 	github.com/cpuguy83/go-md2man/v2 v2.0.2 // indirect
 	github.com/inconshreveable/mousetrap v1.0.1 // indirect
 	github.com/russross/blackfriday/v2 v2.1.0 // indirect
 	github.com/spbsoluble/go-pkcs12 v0.3.1 // indirect
+	github.com/spbsoluble/keyfactor-go-client-sdk v1.0.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 	go.mozilla.org/pkcs7 v0.0.0-20210826202110-33d05740a352 // indirect
 	golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -6,6 +6,8 @@ github.com/Keyfactor/keyfactor-go-client v1.3.1 h1:PACXm/8ZtxGzSSZ0d+043ntMbHOMS
 github.com/Keyfactor/keyfactor-go-client v1.3.1/go.mod h1:u1M1AjcwiO/Tbvc7EsNl9YTy757hO5wmey1/W/7Qkbs=
 github.com/Keyfactor/keyfactor-go-client v1.3.2-0.20230328010103-e4fe507c6a5f h1:8bShNkvlOd9MFB6BsRMgcBaAPNVq9i44coWCwLAQOX4=
 github.com/Keyfactor/keyfactor-go-client v1.3.2-0.20230328010103-e4fe507c6a5f/go.mod h1:YeiR7zU2GT3bVs99EYYdwImBLu3LBZo7zYi3yS2wawQ=
+github.com/Keyfactor/keyfactor-go-client v1.3.2-0.20230328014202-a92b8603fc5f h1:QS9yuSizZ/Tq/4eQjyn1V5kaNJUvI+XoBiGSBYHW5e4=
+github.com/Keyfactor/keyfactor-go-client v1.3.2-0.20230328014202-a92b8603fc5f/go.mod h1:YeiR7zU2GT3bVs99EYYdwImBLu3LBZo7zYi3yS2wawQ=
 github.com/Keyfactor/keyfactor-go-client v1.4.0 h1:JPzDQ6L12TEbhsDK0SJtCii/qD18sg6pEiWEdPNXl68=
 github.com/Keyfactor/keyfactor-go-client v1.4.0/go.mod h1:DhSKPB1ZXtxojUpTTAFcITTXQPExuWB6saFSTipCupc=
 github.com/Keyfactor/keyfactor-go-client-sdk v0.0.0-20230207174129-9d99e523eb15 h1:tOBT7/oLUtjcFCRDLsQAIv2oSj+59O6PUSveIb5gkZQ=

--- a/go.sum
+++ b/go.sum
@@ -4,8 +4,14 @@ github.com/Keyfactor/keyfactor-go-client v1.2.1-0.20230207180411-19f63f6d48b8 h1
 github.com/Keyfactor/keyfactor-go-client v1.2.1-0.20230207180411-19f63f6d48b8/go.mod h1:qG9ZJTt0o5YPV2+QW4Gb9Dub9dnwQvx+G48QUVfjKRA=
 github.com/Keyfactor/keyfactor-go-client v1.3.1 h1:PACXm/8ZtxGzSSZ0d+043ntMbHOMS7bi46zX2fn8Yq4=
 github.com/Keyfactor/keyfactor-go-client v1.3.1/go.mod h1:u1M1AjcwiO/Tbvc7EsNl9YTy757hO5wmey1/W/7Qkbs=
+github.com/Keyfactor/keyfactor-go-client v1.3.2-0.20230328010103-e4fe507c6a5f h1:8bShNkvlOd9MFB6BsRMgcBaAPNVq9i44coWCwLAQOX4=
+github.com/Keyfactor/keyfactor-go-client v1.3.2-0.20230328010103-e4fe507c6a5f/go.mod h1:YeiR7zU2GT3bVs99EYYdwImBLu3LBZo7zYi3yS2wawQ=
+github.com/Keyfactor/keyfactor-go-client v1.4.0 h1:JPzDQ6L12TEbhsDK0SJtCii/qD18sg6pEiWEdPNXl68=
+github.com/Keyfactor/keyfactor-go-client v1.4.0/go.mod h1:DhSKPB1ZXtxojUpTTAFcITTXQPExuWB6saFSTipCupc=
 github.com/Keyfactor/keyfactor-go-client-sdk v0.0.0-20230207174129-9d99e523eb15 h1:tOBT7/oLUtjcFCRDLsQAIv2oSj+59O6PUSveIb5gkZQ=
 github.com/Keyfactor/keyfactor-go-client-sdk v0.0.0-20230207174129-9d99e523eb15/go.mod h1:vDv1/UDRv3BQHyThh1ibGlOpxsN73FK9KkLVSPnWUFA=
+github.com/Keyfactor/keyfactor-go-client-sdk v0.1.0 h1:dYWy45rhAPsqEifPhMMqnTI/VL9O2gWw+ZqYmWgMF0A=
+github.com/Keyfactor/keyfactor-go-client-sdk v0.1.0/go.mod h1:Z5pSk8YFGXHbKeQ1wTzVN8A4P/fZmtAwqu3NgBHbDOs=
 github.com/cpuguy83/go-md2man/v2 v2.0.2 h1:p1EgwI/C7NhT0JmVkwCD2ZBK8j4aeHQX2pMHHBfMQ6w=
 github.com/cpuguy83/go-md2man/v2 v2.0.2/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -17,6 +23,8 @@ github.com/russross/blackfriday/v2 v2.1.0 h1:JIOH55/0cWyOuilr9/qlrm0BSXldqnqwMsf
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/spbsoluble/go-pkcs12 v0.3.1 h1:3DWrjdP3HOeYW6aTUSO9pqqAgRL8VKZLqvD5PGkLVMo=
 github.com/spbsoluble/go-pkcs12 v0.3.1/go.mod h1:MX7DY37hx8xHKEMuJ16EMaVT8sT+4KPqK4gTTLFGcH0=
+github.com/spbsoluble/keyfactor-go-client-sdk v1.0.0 h1:NWZWEzLFYhgMREsjV5GrlizOYF2V/hOto4fjeTvb2Dw=
+github.com/spbsoluble/keyfactor-go-client-sdk v1.0.0/go.mod h1:Ka1Nd+ORcfF5wesPXern7ncCClnpJZAqqjF8S8EDCio=
 github.com/spf13/cobra v1.6.1 h1:o94oiPyS4KD1mPy2fmcYYHHfCxLqYjJOhGsCHFZtEzA=
 github.com/spf13/cobra v1.6.1/go.mod h1:IOw/AERYS7UzyrGinqmz6HLUo219MORXGxhbaJUqzrY=
 github.com/spf13/pflag v1.0.5 h1:iy+VFUOCP1a+8yFto/drg2CJ5u0yRoB7fZw3DKv/JXA=


### PR DESCRIPTION
Updated keyfactor-go-client-sdk import statements to reflect the now public keyfactor-go-client-sdk (https://github.com/Keyfactor/keyfactor-go-client-sdk) repo.