### PR TITLE
feat(helm): `helm` command path for Chart CLI configuration tool

### DIFF
--- a/cmd/helm.go
+++ b/cmd/helm.go
@@ -1,0 +1,61 @@
+package cmd
+
+import (
+	"github.com/spf13/cobra"
+	"kfutil/pkg/helm"
+	"log"
+)
+
+// helmCmd represents the storeTypes command
+var helmCmd = &cobra.Command{
+	Use:   "helm",
+	Short: "Keyfactor Helm Chart Utilities",
+	Long:  `Keyfactor Helm Chart Utilities used to configure charts and assist in the deployment of Keyfactor products.`,
+}
+
+var helmUoCmd = &cobra.Command{
+	Use:   "uo",
+	Short: "Keyfactor Helm Chart Utilities for the Containerized Universal Orchestrator",
+	Long:  `Keyfactor Helm Chart Utilities used to configure charts and assist in the deployment of the Keyfactor Command Universal Orchestrator.`,
+	Run:   UoValueBuilder,
+}
+
+func UoValueBuilder(cmd *cobra.Command, args []string) {
+	// Global flags
+	debugFlag, _ := cmd.Flags().GetBool("debug")
+	noPrompt, _ := cmd.Flags().GetBool("no-prompt")
+	profile, _ := cmd.Flags().GetString("profile")
+	debugModeEnabled := checkDebug(debugFlag)
+	log.Println("Debug mode enabled: ", debugModeEnabled)
+	commandConfig, _ := authConfigFile("", profile, noPrompt, false)
+
+	valueFile, _ := cmd.Flags().GetString("values")
+	githubToken, _ := cmd.Flags().GetString("token")
+	outputFile, _ := cmd.Flags().GetString("out")
+
+	uo := helm.NewUniversalOrchestratorHelmValueBuilder(valueFile)
+	if githubToken != "" {
+		uo.SetGithubToken(githubToken)
+	}
+	if outputFile != "" {
+		uo.SetOverrideFile(outputFile)
+	}
+	if commandConfig.Servers["profile"].Hostname != "" {
+		// TODO this could panic if authConfigFile fails
+		uo.SetHostname(commandConfig.Servers["profile"].Hostname)
+	}
+
+	uo.Build()
+}
+
+func init() {
+	RootCmd.AddCommand(helmCmd)
+
+	// Helm UO (Universal Orchestrator) Command
+	var valuesFile, githubToken, outputFile string
+	helmCmd.AddCommand(helmUoCmd)
+	helmUoCmd.Flags().StringVarP(&valuesFile, "values", "f", "", "values.yaml file to use as base for the chart")
+	_ = helmUoCmd.MarkFlagRequired("values")
+	helmUoCmd.Flags().StringVarP(&outputFile, "out", "o", "", "Path to output the modified values.yaml file. This file can then be used with helm install -f <file> to override the default values.")
+	helmUoCmd.Flags().StringVarP(&githubToken, "token", "t", "", "GitHub token to use for API calls")
+}

--- a/pkg/helm/ca_config.go
+++ b/pkg/helm/ca_config.go
@@ -1,0 +1,225 @@
+package helm
+
+import (
+	"fmt"
+	"github.com/AlecAivazis/survey/v2"
+	"strings"
+)
+
+const (
+	caVolumeName         = "root-ca"
+	defaultConfigMapName = "ca-roots"
+	defaultMountPath     = "/etc/ssl/certs"
+	defaultFileName      = "ca-certificates.crt"
+)
+
+func (b *UniversalOrchestratorHelmValueBuilder) caChainConfiguration() error {
+	// First, determine if the values.yaml already configured the CA chain
+	// If one is installed, there will be a volume called root-ca and a volume mount called root-ca
+
+	configuredConfigMapName := ""
+	mountPath := ""
+	fileName := ""
+
+	volumeExists := false
+	configMapConfigured := false
+	for _, volume := range b.values.Volumes {
+		if volume.Name == caVolumeName {
+			configuredConfigMapName = volume.ConfigMap.Name
+			for _, item := range volume.ConfigMap.Items {
+				fileName = item.Path
+				configMapConfigured = true
+			}
+			volumeExists = true
+		}
+	}
+
+	volumeMountExists := false
+	for _, mount := range b.values.VolumeMounts {
+		if mount.Name == caVolumeName {
+			mountPath = mount.MountPath
+			volumeMountExists = true
+		}
+	}
+
+	mountPath = strings.Replace(mountPath, fmt.Sprintf("/%s", fileName), "", -1)
+
+	// There are three copies of these variables so that changes can be accurately tracked and displayed to user
+	defaultConfigMapNameSetting := ""
+	if configuredConfigMapName == "" {
+		defaultConfigMapNameSetting = defaultConfigMapName
+	} else {
+		defaultConfigMapNameSetting = configuredConfigMapName
+	}
+
+	defaultMountPathSetting := ""
+	if mountPath == "" {
+		defaultMountPathSetting = defaultMountPath
+	} else {
+		defaultMountPathSetting = mountPath
+	}
+
+	defaultFileNameSetting := ""
+	if fileName == "" {
+		defaultFileNameSetting = defaultFileName
+	} else {
+		defaultFileNameSetting = fileName
+	}
+
+	newConfigMapName := ""
+	prompt := survey.Input{
+		Message: "Enter the name of the configmap containing the CA chain",
+		Default: defaultConfigMapNameSetting,
+	}
+	err := survey.AskOne(&prompt, &newConfigMapName, survey.WithValidator(survey.Required))
+	if err != nil {
+		return err
+	}
+
+	newFileName := ""
+	prompt = survey.Input{
+		Message: "Enter the file name of the certificate inside the configmap. In most cases this should be ca-certificates.crt",
+		Default: defaultFileNameSetting,
+	}
+	err = survey.AskOne(&prompt, &newFileName, survey.WithValidator(survey.Required))
+	if err != nil {
+		return err
+	}
+
+	newMountPath := ""
+	prompt = survey.Input{
+		Message: "Enter the mount path where the certificate inside the configmap will be mounted",
+		Default: defaultMountPathSetting,
+	}
+	err = survey.AskOne(&prompt, &newMountPath, survey.WithValidator(survey.Required))
+	if err != nil {
+		return err
+	}
+
+	// Print the results for the user to confirm
+	printConfirmation(configuredConfigMapName, newConfigMapName, mountPath, newMountPath, fileName, newFileName, volumeExists, volumeMountExists, configMapConfigured)
+
+	// Confirm that the user wants to save the changes
+	confirm := false
+	confirmPrompt := &survey.Confirm{
+		Message: "Save changes?",
+		Default: true,
+	}
+	err = survey.AskOne(confirmPrompt, &confirm)
+	if err != nil {
+		return err
+	}
+
+	if confirm {
+		b.syncVolumeConfiguration(newConfigMapName, newMountPath, newFileName)
+	}
+
+	return b.MainMenu()
+}
+
+func (b *UniversalOrchestratorHelmValueBuilder) syncVolumeConfiguration(configMapName, mountPath, fileName string) {
+	// First handle the volume/configmap
+	volumeExists := false
+	for i, volume := range b.values.Volumes {
+		if volume.Name == caVolumeName {
+			volumeExists = true
+			b.values.Volumes[i].ConfigMap.Name = configMapName
+			b.values.Volumes[i].ConfigMap.Items = make([]ConfigMapItem, 0)
+			b.values.Volumes[i].ConfigMap.Items = append(b.values.Volumes[i].ConfigMap.Items, ConfigMapItem{Key: fileName, Path: fileName})
+		}
+	}
+
+	// If the volume doesn't exist, create it
+	if !volumeExists {
+		newVolume := Volume{}
+		newVolume.Name = caVolumeName
+		newVolume.ConfigMap.Name = configMapName
+		newVolume.ConfigMap.Items = append(make([]ConfigMapItem, 0), ConfigMapItem{Key: fileName, Path: fileName})
+		b.values.Volumes = append(b.values.Volumes, newVolume)
+	}
+
+	// Next, handle the volume mount
+	volumeMountExists := false
+	for i, mount := range b.values.VolumeMounts {
+		if mount.Name == caVolumeName {
+			volumeMountExists = true
+			b.values.VolumeMounts[i].MountPath = mountPath
+			b.values.VolumeMounts[i].SubPath = fileName
+		}
+	}
+
+	// If the volume mount doesn't exist, create it
+	if !volumeMountExists {
+		newVolumeMount := VolumeMount{}
+		newVolumeMount.Name = caVolumeName
+		newVolumeMount.MountPath = fmt.Sprintf("%s/%s", mountPath, fileName)
+		newVolumeMount.SubPath = fileName
+		b.values.VolumeMounts = append(b.values.VolumeMounts, newVolumeMount)
+	}
+}
+
+func printConfirmation(oldConfigMapName, newConfigMapName, oldMountPath, newMountPath, oldFileName, newFileName string, volumeExists, volumeMountExists, configMapConfigured bool) {
+	const (
+		red    = "31"
+		green  = "32"
+		yellow = "33"
+	)
+
+	fmt.Println("The following changes will be made:")
+
+	// Helper function to print messages with color
+	printWithColor := func(prepend, text, colorCode string) {
+		fmt.Printf("\033[%sm%s\033[0m%s\n", colorCode, prepend, text)
+	}
+
+	// First, print the volume configuration
+	if volumeExists {
+		printWithColor("~ ", "volumes:", yellow)
+		printWithColor("~ ", "  - name: root-ca", yellow)
+	} else {
+		printWithColor("+ ", "volumes:", green)
+		printWithColor("+ ", "  - name: root-ca", green)
+	}
+
+	// Next, print the configmap configuration
+	if configMapConfigured {
+		printWithColor("~ ", "    configMap:", yellow)
+		if oldConfigMapName != newConfigMapName {
+			printWithColor("+ ", fmt.Sprintf("      name: %q -> %q", oldConfigMapName, newConfigMapName), green)
+		} else {
+			printWithColor("~ ", fmt.Sprintf("      name: %q", newConfigMapName), yellow)
+		}
+	} else {
+		printWithColor("+ ", "    configMap:", green)
+		printWithColor("+ ", fmt.Sprintf("      name: %q", newConfigMapName), green)
+	}
+
+	// Next, print the fileName configuration
+	if oldFileName != newFileName {
+		printWithColor("+ ", fmt.Sprintf("      items:"), green)
+		printWithColor("+ ", fmt.Sprintf("        - key: %q -> %q", oldFileName, newFileName), green)
+		printWithColor("+ ", fmt.Sprintf("          path: %q -> %q", oldFileName, newFileName), green)
+	} else {
+		printWithColor("~ ", fmt.Sprintf("      items:"), yellow)
+		printWithColor("~ ", fmt.Sprintf("        - key: %q", newFileName), yellow)
+		printWithColor("~ ", fmt.Sprintf("          path: %q", newFileName), yellow)
+	}
+
+	// Finally, print the mountPath configuration
+	oldMountPath = fmt.Sprintf("%s/%s", oldMountPath, oldFileName)
+	newMountPath = fmt.Sprintf("%s/%s", newMountPath, newFileName)
+	if volumeMountExists {
+		printWithColor("~ ", "volumeMounts:", yellow)
+		printWithColor("~ ", "  - name: root-ca", yellow)
+		if oldMountPath != newMountPath {
+			printWithColor("+ ", fmt.Sprintf("  - mountPath: %q -> %q", oldMountPath, newMountPath), green)
+		} else {
+			printWithColor("~ ", fmt.Sprintf("  - mountPath: %q", newMountPath), yellow)
+		}
+	} else {
+		printWithColor("+ ", "volumeMounts:", green)
+		printWithColor("+ ", "  - name: root-ca", green)
+		printWithColor("+ ", fmt.Sprintf("  - mountPath: %q", newMountPath), green)
+		printWithColor("+ ", fmt.Sprintf("    subPath: %q", newFileName), green)
+	}
+}

--- a/pkg/helm/extensions.go
+++ b/pkg/helm/extensions.go
@@ -1,0 +1,242 @@
+package helm
+
+import (
+	"encoding/json"
+	"fmt"
+	"github.com/AlecAivazis/survey/v2"
+	"io"
+	"net/http"
+	"strings"
+)
+
+func (b *UniversalOrchestratorHelmValueBuilder) selectExtensionsHandler() error {
+	ghTool := NewGithubReleaseFetcher(b.token)
+	extensions, err := ghTool.GetExtensionList()
+	if err != nil {
+		return err
+	}
+
+	// Get a list of currently installed extensions
+	installedExtensions := make(Extensions)
+	for _, container := range b.values.InitContainers {
+		extensionName := ""
+		extensionVersion := ""
+		for _, env := range container.Env {
+			if env.Name == "EXTENSION_NAME" {
+				extensionName = env.Value
+			}
+			if env.Name == "EXTENSION_VERSION" {
+				extensionVersion = env.Value
+			}
+		}
+		if extensionName != "" {
+			installedExtensions[extensionName] = append(installedExtensions[extensionName], extensionVersion)
+		}
+	}
+
+	extensionNameList := make([]string, 0)
+	for extensionName, _ := range extensions {
+		extensionNameList = append(extensionNameList, extensionName)
+	}
+
+	descriptionFunc := func(value string, index int) string {
+		for extensionName, versions := range extensions {
+			if extensionName == value {
+				description := fmt.Sprintf("%s", versions[0])
+
+				if installed, ok := installedExtensions[extensionName]; ok {
+					description = fmt.Sprintf("%s (currently %s)", description, installed[0])
+				}
+
+				return description
+			}
+		}
+		return ""
+	}
+
+	var extensionsToInstall []string
+	prompt := &survey.MultiSelect{
+		Message:     "Select the extensions to install - the most recent versions are displayed",
+		Options:     alphabetize(extensionNameList),
+		Description: descriptionFunc,
+	}
+	err = survey.AskOne(prompt, &extensionsToInstall)
+	if err != nil {
+		return err
+	}
+
+	for _, extension := range extensionsToInstall {
+		// extensionsToInstall is a subset of extensions since user was prompted to select from extensions
+		// So we can safely assume that extension is in extensions
+		versions := extensions[extension]
+		// Also, extensions is only populated if there are releases for the extension
+		latestVersion := versions[0]
+
+		initContainerName := fmt.Sprintf("%s-installer", extension)
+		extensionAlreadyInstalled := false
+
+		// If the extension is already covered in the Init Containers, upgrade it
+		for i, container := range b.values.InitContainers {
+			if container.Name == initContainerName {
+				extensionAlreadyInstalled = true
+				for j, env := range container.Env {
+					if env.Name == "EXTENSION_VERSION" && env.Value != latestVersion {
+						fmt.Printf("Upgrading %s from %s to %s\n", extension, env.Value, latestVersion)
+						b.values.InitContainers[i].Env[j].Value = latestVersion
+						break
+					} else if env.Name == "EXTENSION_VERSION" && env.Value == latestVersion {
+						fmt.Printf("Extension %s is already configured for version %s\n", extension, latestVersion)
+					}
+				}
+				break
+			}
+		}
+
+		if extensionAlreadyInstalled {
+			continue
+		}
+
+		b.values.InitContainers = append(b.values.InitContainers, InitContainer{
+			Name:            initContainerName,
+			Image:           installerImage,
+			ImagePullPolicy: installerImagePullPolicy,
+			Env: []Environment{
+				{
+					Name:  "EXTENSION_NAME",
+					Value: extension,
+				},
+				{
+					Name:  "EXTENSION_VERSION",
+					Value: latestVersion,
+				},
+				{
+					Name:  "INSTALL_PATH",
+					Value: fmt.Sprintf("/app/extensions/%s", extension),
+				},
+			},
+			VolumeMounts: []VolumeMount{
+				{
+					Name:      b.values.ExtensionStorage.Name,
+					MountPath: "/app/extensions",
+				},
+			},
+		})
+	}
+
+	// Return to the main menu
+	return b.MainMenu()
+}
+
+type Extensions map[string][]string
+
+type GithubReleaseFetcher struct {
+	token string
+}
+
+func NewGithubReleaseFetcher(token string) *GithubReleaseFetcher {
+	return &GithubReleaseFetcher{
+		token: token,
+	}
+}
+
+func (g *GithubReleaseFetcher) getOrchestratorNames() ([]string, error) {
+	orchestratorList := make([]string, 0)
+	page := 1
+
+	for {
+		// Prevent rate limiting
+		if page > 10 {
+			break
+		}
+
+		// Ask https://api.github.com/orgs/keyfactor/repos for the list of repos
+		// Unmarshal the body into a slice of gitHubRepo structs
+		var repos []gitHubRepo
+		err := g.Get(fmt.Sprintf("https://api.github.com/orgs/keyfactor/repos?page=%d&per_page=100", page), &repos)
+		if err != nil {
+			return nil, err
+		}
+
+		// If the length of the repos slice is 0, we've reached the end of the list
+		if len(repos) == 0 {
+			break
+		}
+
+		// Loop through the repos and add them to the orchestratorList slice
+		for _, repo := range repos {
+			if strings.Contains(repo.Name, "-orchestrator") {
+				orchestratorList = append(orchestratorList, repo.Name)
+			}
+		}
+
+		page++
+	}
+
+	return orchestratorList, nil
+}
+
+func (g *GithubReleaseFetcher) GetExtensionList() (Extensions, error) {
+	extensionNameList, err := g.getOrchestratorNames()
+	if err != nil {
+		return nil, err
+	}
+
+	extensions := make(Extensions)
+
+	for _, extensionName := range extensionNameList {
+		// Ask https://api.github.com/repos/keyfactor/{name}/releases for the list of releases
+		// Unmarshal the body into a slice of gitHubRelease structs
+		var releases []gitHubRelease
+		err = g.Get(fmt.Sprintf("https://api.github.com/repos/keyfactor/%s/releases", extensionName), &releases)
+		if err != nil {
+			return nil, err
+		}
+
+		// Add the extension to the list of extensions
+		versions := make([]string, 0)
+		for _, release := range releases {
+			if !release.Prerelease {
+				versions = append(versions, release.TagName)
+			}
+		}
+		if len(versions) > 0 {
+			extensions[extensionName] = versions
+		}
+	}
+
+	return extensions, nil
+}
+
+func (g *GithubReleaseFetcher) Get(url string, v any) error {
+	client := http.DefaultClient
+
+	req, err := http.NewRequest("GET", url, nil)
+	if err != nil {
+		return err
+	}
+
+	// Add Authorization header
+	if g.token != "" {
+		req.Header.Set("Authorization", "Bearer "+g.token)
+	}
+
+	get, err := client.Do(req)
+	if err != nil {
+		return err
+	}
+
+	// Read the body of the response
+	body, err := io.ReadAll(get.Body)
+	if err != nil {
+		return err
+	}
+
+	// Unmarshal the body
+	// TODO this could panic if the body is not valid JSON
+	err = json.Unmarshal(body, v)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/pkg/helm/models.go
+++ b/pkg/helm/models.go
@@ -1,0 +1,154 @@
+package helm
+
+import "time"
+
+type InitContainer struct {
+	Name            string        `yaml:"name"`
+	Image           string        `yaml:"image"`
+	ImagePullPolicy string        `yaml:"imagePullPolicy"`
+	Env             []Environment `yaml:"env"`
+	VolumeMounts    []VolumeMount `yaml:"volumeMounts"`
+}
+
+type Environment struct {
+	Name  string `yaml:"name"`
+	Value string `yaml:"value"`
+}
+
+type VolumeMount struct {
+	Name      string `yaml:"name"`
+	MountPath string `yaml:"mountPath"`
+	SubPath   string `yaml:"subPath"`
+	ReadOnly  bool   `yaml:"readOnly"`
+}
+
+type Volume struct {
+	ConfigMap struct {
+		Items []ConfigMapItem `yaml:"items"`
+		Name  string          `yaml:"name"`
+	} `yaml:"configMap"`
+	Name string `yaml:"name"`
+}
+
+type ConfigMapItem struct {
+	Key  string `yaml:"key"`
+	Path string `yaml:"path"`
+}
+
+type UniversalOrchestratorHelmValues struct {
+	Name     string `yaml:"name"`
+	Fullname string `yaml:"fullname"`
+	Image    struct {
+		Repository string `yaml:"repository"`
+		PullPolicy string `yaml:"pullPolicy"`
+		Tag        string `yaml:"tag"`
+	} `yaml:"image"`
+	CommandAgentURL string `yaml:"commandAgentUrl"`
+	Auth            struct {
+		SecretName             string `yaml:"secretName"`
+		UseOauthAuthentication bool   `yaml:"useOauthAuthentication"`
+	} `yaml:"auth"`
+	LogLevel         string          `yaml:"logLevel"`
+	ImagePullSecrets []interface{}   `yaml:"imagePullSecrets"`
+	InitContainers   []InitContainer `yaml:"initContainers"`
+	ServiceAccount   struct {
+		Create      bool   `yaml:"create"`
+		Name        string `yaml:"name"`
+		Annotations struct {
+		} `yaml:"annotations"`
+	} `yaml:"serviceAccount"`
+	ExtensionStorage struct {
+		Name         string `yaml:"name"`
+		StorageClass string `yaml:"storageClass"`
+		Size         string `yaml:"size"`
+		AccessMode   string `yaml:"accessMode"`
+		Annotations  struct {
+		} `yaml:"annotations"`
+	} `yaml:"extensionStorage"`
+	Volumes         []Volume      `yaml:"volumes"`
+	VolumeMounts    []VolumeMount `yaml:"volumeMounts"`
+	ExtraContainers interface{}   `yaml:"extraContainers"`
+	PostStart       []string      `yaml:"postStart"`
+}
+
+type gitHubRepo struct {
+	ID          int    `json:"id"`
+	NodeID      string `json:"node_id"`
+	Name        string `json:"name"`
+	FullName    string `json:"full_name"`
+	HTMLURL     string `json:"html_url"`
+	Description string `json:"description"`
+}
+
+type gitHubRelease struct {
+	URL       string `json:"url"`
+	AssetsURL string `json:"assets_url"`
+	UploadURL string `json:"upload_url"`
+	HTMLURL   string `json:"html_url"`
+	ID        int    `json:"id"`
+	Author    struct {
+		Login             string `json:"login"`
+		ID                int    `json:"id"`
+		NodeID            string `json:"node_id"`
+		AvatarURL         string `json:"avatar_url"`
+		GravatarID        string `json:"gravatar_id"`
+		URL               string `json:"url"`
+		HTMLURL           string `json:"html_url"`
+		FollowersURL      string `json:"followers_url"`
+		FollowingURL      string `json:"following_url"`
+		GistsURL          string `json:"gists_url"`
+		StarredURL        string `json:"starred_url"`
+		SubscriptionsURL  string `json:"subscriptions_url"`
+		OrganizationsURL  string `json:"organizations_url"`
+		ReposURL          string `json:"repos_url"`
+		EventsURL         string `json:"events_url"`
+		ReceivedEventsURL string `json:"received_events_url"`
+		Type              string `json:"type"`
+		SiteAdmin         bool   `json:"site_admin"`
+	} `json:"author"`
+	NodeID          string    `json:"node_id"`
+	TagName         string    `json:"tag_name"`
+	TargetCommitish string    `json:"target_commitish"`
+	Name            string    `json:"name"`
+	Draft           bool      `json:"draft"`
+	Prerelease      bool      `json:"prerelease"`
+	CreatedAt       time.Time `json:"created_at"`
+	PublishedAt     time.Time `json:"published_at"`
+	Assets          []struct {
+		URL      string `json:"url"`
+		ID       int    `json:"id"`
+		NodeID   string `json:"node_id"`
+		Name     string `json:"name"`
+		Label    string `json:"label"`
+		Uploader struct {
+			Login             string `json:"login"`
+			ID                int    `json:"id"`
+			NodeID            string `json:"node_id"`
+			AvatarURL         string `json:"avatar_url"`
+			GravatarID        string `json:"gravatar_id"`
+			URL               string `json:"url"`
+			HTMLURL           string `json:"html_url"`
+			FollowersURL      string `json:"followers_url"`
+			FollowingURL      string `json:"following_url"`
+			GistsURL          string `json:"gists_url"`
+			StarredURL        string `json:"starred_url"`
+			SubscriptionsURL  string `json:"subscriptions_url"`
+			OrganizationsURL  string `json:"organizations_url"`
+			ReposURL          string `json:"repos_url"`
+			EventsURL         string `json:"events_url"`
+			ReceivedEventsURL string `json:"received_events_url"`
+			Type              string `json:"type"`
+			SiteAdmin         bool   `json:"site_admin"`
+		} `json:"uploader"`
+		ContentType        string    `json:"content_type"`
+		State              string    `json:"state"`
+		Size               int       `json:"size"`
+		DownloadCount      int       `json:"download_count"`
+		CreatedAt          time.Time `json:"created_at"`
+		UpdatedAt          time.Time `json:"updated_at"`
+		BrowserDownloadURL string    `json:"browser_download_url"`
+	} `json:"assets"`
+	TarballURL string `json:"tarball_url"`
+	ZipballURL string `json:"zipball_url"`
+	Body       string `json:"body"`
+}

--- a/pkg/helm/uo.go
+++ b/pkg/helm/uo.go
@@ -1,0 +1,310 @@
+package helm
+
+import (
+	"fmt"
+	"github.com/AlecAivazis/survey/v2"
+	"gopkg.in/yaml.v3"
+	"os"
+	"sort"
+)
+
+const (
+	defaultOverrideFile      = "override.yaml"
+	installerImage           = "m8rmclarenkf/uo_extension_installer:1.0.5"
+	installerImagePullPolicy = "IfNotPresent"
+)
+
+type UniversalOrchestratorHelmValueBuilder struct {
+	commandHostname string
+	valuesFile      string
+	overrideFile    string
+	token           string
+	values          UniversalOrchestratorHelmValues
+}
+
+type menuOption struct {
+	optionName   string
+	optionDesc   string
+	currentValue string
+	handlerFunc  func() error
+}
+
+func NewUniversalOrchestratorHelmValueBuilder(filePath string) *UniversalOrchestratorHelmValueBuilder {
+	return &UniversalOrchestratorHelmValueBuilder{
+		valuesFile:   filePath,
+		overrideFile: defaultOverrideFile,
+	}
+}
+
+func (b *UniversalOrchestratorHelmValueBuilder) SetGithubToken(token string) {
+	b.token = token
+}
+
+func (b *UniversalOrchestratorHelmValueBuilder) SetOverrideFile(filePath string) {
+	b.overrideFile = filePath
+}
+
+func (b *UniversalOrchestratorHelmValueBuilder) SetHostname(hostname string) {
+	b.commandHostname = hostname
+}
+
+func (b *UniversalOrchestratorHelmValueBuilder) load() error {
+	// Read in the values file and marshal it into the values struct
+	buf, err := os.ReadFile(b.valuesFile)
+	if err != nil {
+		return err
+	}
+
+	err = yaml.Unmarshal(buf, &b.values)
+	if err != nil {
+		return err
+	}
+
+	// Set the Command Agent URL to the hostname of the currently logged-in user if it is not already set
+	if b.values.CommandAgentURL == "" {
+		b.values.CommandAgentURL = fmt.Sprintf("https://%s/KeyfactorAgents", b.commandHostname)
+	}
+
+	return nil
+}
+
+func (b *UniversalOrchestratorHelmValueBuilder) Build() {
+	err := b.load()
+	if err != nil {
+		fmt.Printf("Failed to load values file: %v\n", err)
+		return
+	}
+
+	err = b.MainMenu()
+	if err != nil {
+		fmt.Printf("Error: %v\n", err)
+		return
+	}
+}
+
+func (b *UniversalOrchestratorHelmValueBuilder) MainMenu() error {
+	mainMenuOptions := []menuOption{
+		{
+			optionName:   "Change Name",
+			optionDesc:   "Change the name of the chart",
+			currentValue: b.values.Name,
+			handlerFunc: func() error {
+				prompt := survey.Input{
+					Renderer: survey.Renderer{},
+					Message:  "Enter the name of the chart",
+					Default:  b.values.Name,
+				}
+				err := survey.AskOne(&prompt, &b.values.Name, survey.WithValidator(survey.Required))
+				if err != nil {
+					return err
+				}
+
+				// Return to the main menu
+				return b.MainMenu()
+			},
+		},
+		{
+			optionName:   "Change Command Agent URL",
+			optionDesc:   "Change the base URL to the Command Agents API",
+			currentValue: b.values.CommandAgentURL,
+			handlerFunc: func() error {
+				prompt := survey.Input{
+					Renderer: survey.Renderer{},
+					Message:  "Enter the base URL to the Command Agents API",
+					Default:  b.values.CommandAgentURL,
+				}
+				err := survey.AskOne(&prompt, &b.values.CommandAgentURL, survey.WithValidator(survey.Required))
+				if err != nil {
+					return err
+				}
+
+				// Return to the main menu
+				return b.MainMenu()
+			},
+		},
+		{
+			optionName:   "Change Log Level",
+			optionDesc:   "Change the log level of the Universal Orchestrator container",
+			currentValue: b.values.LogLevel,
+			handlerFunc: func() error {
+				prompt := survey.Select{
+					Message: "Select the log level of the Universal Orchestrator container",
+					Options: []string{"Debug", "Info", "Warn", "Error"},
+					Default: b.values.LogLevel,
+				}
+				err := survey.AskOne(&prompt, &b.values.LogLevel, survey.WithValidator(survey.Required))
+				if err != nil {
+					return err
+				}
+
+				// Return to the main menu
+				return b.MainMenu()
+			},
+		},
+		{
+			optionName:  "Change Image",
+			optionDesc:  "Change the Universal Orchestrator container image that the chart will use",
+			handlerFunc: b.imageHandler,
+		},
+		{
+			optionName:   "Container Root CA Certificate Configuration",
+			optionDesc:   "Configure the Universal Orchestrator container to trust a custom CA certificate chain",
+			currentValue: "",
+			handlerFunc:  b.caChainConfiguration,
+		},
+		{
+			optionName:   "Configure Orchestrator Extensions",
+			optionDesc:   "Set the orchestrator extensions to install with the chart",
+			currentValue: fmt.Sprintf("%d extensions", len(b.values.InitContainers)),
+			handlerFunc:  b.selectExtensionsHandler,
+		},
+		{
+			optionName:   "Save and Exit",
+			optionDesc:   "Exit the program and write the new values to override.yaml",
+			currentValue: "",
+			handlerFunc: func() error {
+				// Marshal the values struct into a yaml string
+				buf, err := yaml.Marshal(b.values)
+				if err != nil {
+					return err
+				}
+
+				// Write the yaml string locally to an override file
+				err = os.WriteFile(b.overrideFile, buf, 0644)
+
+				// TODO print Helm command to install the chart
+				return nil
+			},
+		},
+	}
+
+	return b.handleOptions(mainMenuOptions, "Main Menu")
+}
+
+func (b *UniversalOrchestratorHelmValueBuilder) imageHandler() error {
+	imageOptions := []menuOption{
+		{
+			optionName:   "Change Image Repository",
+			optionDesc:   "Change the repository of the Universal Orchestrator container image",
+			currentValue: b.values.Image.Repository,
+			handlerFunc: func() error {
+				prompt := survey.Input{
+					Message: "Enter the repository of the Universal Orchestrator container image",
+					Default: b.values.Image.Repository,
+				}
+				err := survey.AskOne(&prompt, &b.values.Image.Repository, survey.WithValidator(survey.Required))
+				if err != nil {
+					return err
+				}
+
+				// Return to the main menu
+				return b.imageHandler()
+			},
+		},
+		{
+			optionName:   "Change Image Tag",
+			optionDesc:   "Change the tag of the Universal Orchestrator container image",
+			currentValue: b.values.Image.Tag,
+			handlerFunc: func() error {
+				prompt := survey.Input{
+					Message: "Enter the tag of the Universal Orchestrator container image",
+					Default: b.values.Image.Tag,
+				}
+				err := survey.AskOne(&prompt, &b.values.Image.Tag, survey.WithValidator(survey.Required))
+				if err != nil {
+					return err
+				}
+
+				// Return to the main menu
+				return b.imageHandler()
+			},
+		},
+		{
+			optionName:   "Change Image Pull Policy",
+			optionDesc:   "Change the pull policy of the Universal Orchestrator container image",
+			currentValue: b.values.Image.PullPolicy,
+			handlerFunc: func() error {
+				prompt := survey.Input{
+					Message: "Enter the pull policy to use when pulling the Universal Orchestrator container image",
+					Default: b.values.Image.PullPolicy,
+				}
+				err := survey.AskOne(&prompt, &b.values.Image.PullPolicy, survey.WithValidator(survey.Required))
+				if err != nil {
+					return err
+				}
+
+				// Return to the main menu
+				return b.imageHandler()
+			},
+		},
+		{
+			optionName:   "Main Menu",
+			optionDesc:   "Return to the main menu",
+			currentValue: "",
+			handlerFunc: func() error {
+				// Return to the main menu
+				return b.MainMenu()
+			},
+		},
+	}
+
+	return b.handleOptions(imageOptions, "Image Menu")
+}
+
+func (b *UniversalOrchestratorHelmValueBuilder) handleOptions(options []menuOption, help string) error {
+	// Build list of options
+	optionStrings := make([]string, 0)
+	for _, option := range options {
+		optionStrings = append(optionStrings, option.optionName)
+	}
+
+	descriptionFunc := func(value string, index int) string {
+		for _, option := range options {
+			if option.optionName == value {
+				desc := option.optionDesc
+				if option.currentValue != "" {
+					desc = fmt.Sprintf("%s (currently %q)", desc, option.currentValue)
+				}
+				return desc
+			}
+		}
+		return ""
+	}
+
+	// Prompt the user to select an option
+	selected := ""
+	prompt := &survey.Select{
+		Message:     "Select an option:",
+		Options:     optionStrings,
+		Help:        help,
+		Description: descriptionFunc,
+	}
+	err := survey.AskOne(prompt, &selected)
+	if err != nil {
+		fmt.Printf("Error: %v\n", err)
+		return err
+	}
+
+	// Call the handler function for the selected option
+	for _, option := range options {
+		if option.optionName == selected {
+			return option.handlerFunc()
+		}
+	}
+
+	// If we get here, the option was not found
+	errorMessage := fmt.Sprintf("error: Option %s not found\n", selected)
+	fmt.Printf(errorMessage)
+	return b.MainMenu()
+}
+
+func alphabetize(list []string) []string {
+	// Make a copy of the original list
+	sortedList := make([]string, len(list))
+	copy(sortedList, list)
+
+	// Sort the copied list alphabetically
+	sort.Strings(sortedList)
+
+	return sortedList
+}


### PR DESCRIPTION
Command line tool that removes the need to manually configure resources for Containerized Universal Orchestrator deployment on Kubernetes, using Helm. The following is an example output of the `kfutil helm uo` command:
```bash
? Select an option:  [Use arrows to move, type to filter, ? for more help]
> Change Name - Change the name of the chart
  Change Command Agent URL - Change the base URL to the Command Agents API
  Change Log Level - Change the log level of the Universal Orchestrator container (currently "Debug")
  Change Image - Change the Universal Orchestrator container image that the chart will use
  Container Root CA Certificate Configuration - Configure the Universal Orchestrator container to trust a custom CA certificate chain
  Configure Orchestrator Extensions - Set the orchestrator extensions to install with the chart (currently "4 extensions")
  Save and Exit - Exit the program and write the new values to override.yaml
```

As of this initial version, the following is the command usage:
```bash
Usage:
  kfutil helm uo [flags]

Flags:
  -h, --help            help for uo
  -o, --out string      Path to output the modified values.yaml file. This file can then be used with helm install -f <file> to override the default values.
  -t, --token string    GitHub token to use for API calls
  -f, --values string   values.yaml file to use as base for the chart
```
