### PR TITLE
fixes for migration commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+# v1.8.1
+
+## Fixes
+
+### CLI
+
+- `migrate pam` will correctly preserve Inventory Schedules on targeted certificate stores
+
 # v1.8.0
 
 ## Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 ### CLI
 
 - `migrate pam` will correctly preserve Inventory Schedules on targeted certificate stores
+- `migrate pam` will migrate matching PAM usages in the Store Password field, or leave value unchanged
+- `migrate check` will reveal matching PAM usages in the Store Password field
 
 # v1.8.0
 

--- a/cmd/migrate.go
+++ b/cmd/migrate.go
@@ -117,6 +117,8 @@ var migrateCheckCmd = &cobra.Command{
 					certStoreGuids[store.Id] = true
 				}
 			}
+
+			// TODO: check Password field for PAM usage
 		}
 
 		// print out list of Cert Store GUIDs
@@ -356,18 +358,67 @@ var migratePamCmd = &cobra.Command{
 			fmt.Println("^^^ SECRETS REFORMATTED ^^^")
 		}
 
+		// check Store Password for PAM field, and process migration if applicable
+		var storePassword *api.UpdateStorePasswordConfig
+		if certStore.Password.IsManaged { // managed secret, i.e. PAM Provider in use
+
+			// check if Pam Secret is using our migrating provider
+			fmt.Println(*fromPamProvider.Id, " <= from id equals store password id => ", int32(certStore.Password.ProviderId))
+			fmt.Println(*fromPamProvider.Id == int32(certStore.Password.ProviderId))
+			if *fromPamProvider.Id == int32(certStore.Password.ProviderId) {
+				// Pam Secret that Needs to be migrated
+				var storePasswordInterface map[string]interface{}
+				// marshal and unmarshal strongly typed store password to match
+				// expected map[string]interface{} typing for helper function
+				storePasswordJson, _ := json.Marshal(certStore.Password)
+				json.Unmarshal(storePasswordJson, &storePasswordInterface)
+
+				// migrate secret using helper function
+				var updateStorePasswordInterface map[string]interface{}
+				updateStorePasswordInterface = buildMigratedPamSecret(storePasswordInterface, fromProviderLevelParamValues, *migrationTargetPamProvider.Id)
+
+				// finally, transform the migrated secret back to the strongly typed input for API client
+				updateStorePasswordJson, _ := json.Marshal(updateStorePasswordInterface)
+				json.Unmarshal(updateStorePasswordJson, &storePassword)
+			} else {
+				// leave Store Password untouched: set to null
+				storePassword = nil
+			}
+		} else {
+			// non-managed secret i.e. a KF-encrypted secret, or no value
+			// instead of reformatting, send null to effect no change
+			storePassword = nil
+		}
+
 		// update property object
 		// set required fields, and new Properties
 		updateStoreArgs := api.UpdateStoreFctArgs{
-			Id:                      certStore.Id,
-			ClientMachine:           certStore.ClientMachine,
-			StorePath:               certStore.StorePath,
-			AgentId:                 certStore.AgentId,
-			Properties:              certStore.Properties,
-			Password:                &certStore.Password, // TODO: secret field, needs to be processed the same as other secret fields
+			Id:            certStore.Id,
+			ClientMachine: certStore.ClientMachine,
+			StorePath:     certStore.StorePath,
+			AgentId:       certStore.AgentId,
+			Properties:    certStore.Properties,
+			Password:      storePassword,
+			// the password should be set to null (omitted) when it is not meant to be updated
+			// however it will need to be migrated if it is a matching PAM secret
+			// check formatting to see if it's a PAM secret
+			// then update to new provider format if it matches
+			// otherwise omit / set to null
+
+			// password PAM format:
+			// { Provider: integer id,
+			//   Parameters: { paramname:value
+			//     Safe: safe,
+			//     Folder: folder,
+			//     Object: object }}
 			InventorySchedule:       &certStore.InventorySchedule,
 			CertStoreInventoryJobId: &certStore.CertStoreInventoryJobId,
 		}
+
+		fmt.Println("vvv REQUESTED UPDATE TO STORE vvv")
+		jobject, _ := json.MarshalIndent(updateStoreArgs, "", "    ")
+		fmt.Println(string(jobject))
+		fmt.Println("^^^ REQUESTED UPDATE TO STORE ^^^")
 
 		// TODO: use updated client when API endpoint available
 		updatedStore, rErr := legacyClient.UpdateStore(&updateStoreArgs)
@@ -378,7 +429,7 @@ var migratePamCmd = &cobra.Command{
 		}
 
 		fmt.Println("vvv UPDATED STORE vvv")
-		jobject, _ := json.MarshalIndent(updatedStore, "", "    ")
+		jobject, _ = json.MarshalIndent(updatedStore, "", "    ")
 		fmt.Println(string(jobject))
 		fmt.Println("^^^ UPDATED STORE ^^^")
 

--- a/cmd/migrate.go
+++ b/cmd/migrate.go
@@ -359,12 +359,14 @@ var migratePamCmd = &cobra.Command{
 		// update property object
 		// set required fields, and new Properties
 		updateStoreArgs := api.UpdateStoreFctArgs{
-			Id:            certStore.Id,
-			ClientMachine: certStore.ClientMachine,
-			StorePath:     certStore.StorePath,
-			AgentId:       certStore.AgentId,
-			Properties:    certStore.Properties,
-			Password:      &certStore.Password,
+			Id:                      certStore.Id,
+			ClientMachine:           certStore.ClientMachine,
+			StorePath:               certStore.StorePath,
+			AgentId:                 certStore.AgentId,
+			Properties:              certStore.Properties,
+			Password:                &certStore.Password, // TODO: secret field, needs to be processed the same as other secret fields
+			InventorySchedule:       &certStore.InventorySchedule,
+			CertStoreInventoryJobId: &certStore.CertStoreInventoryJobId,
 		}
 
 		// TODO: use updated client when API endpoint available

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/Jeffail/gabs v1.4.0
 	github.com/Keyfactor/keyfactor-auth-client-go v1.3.0
 	github.com/Keyfactor/keyfactor-go-client-sdk/v2 v2.0.0
-	github.com/Keyfactor/keyfactor-go-client/v3 v3.1.0
+	github.com/Keyfactor/keyfactor-go-client/v3 v3.2.0-rc.5
 	github.com/Netflix/go-expect v0.0.0-20220104043353-73e0943537d2
 	github.com/creack/pty v1.1.24
 	github.com/google/go-cmp v0.7.0

--- a/go.sum
+++ b/go.sum
@@ -22,8 +22,8 @@ github.com/Keyfactor/keyfactor-auth-client-go v1.3.0 h1:otC213b6CYzqeN9b3CRlH1Qj
 github.com/Keyfactor/keyfactor-auth-client-go v1.3.0/go.mod h1:97vCisBNkdCK0l2TuvOSdjlpvQa4+GHsMut1UTyv1jo=
 github.com/Keyfactor/keyfactor-go-client-sdk/v2 v2.0.0 h1:ehk5crxEGVBwkC8yXsoQXcyITTDlgbxMEkANrl1dA2Q=
 github.com/Keyfactor/keyfactor-go-client-sdk/v2 v2.0.0/go.mod h1:11WXGG9VVKSV0EPku1IswjHbGGpzHDKqD4pe2vD7vas=
-github.com/Keyfactor/keyfactor-go-client/v3 v3.1.0 h1:DQgb93m3xHZZ0FxWGFS90XI8prwS5fmIGrXNxP2IfHM=
-github.com/Keyfactor/keyfactor-go-client/v3 v3.1.0/go.mod h1:LhIBGzTZeZ6o4i0gNg4qmwpwBnkoI6AfcEz8PLKruvc=
+github.com/Keyfactor/keyfactor-go-client/v3 v3.2.0-rc.5 h1:sDdRCGa94GLSBL6mNFiSOuQZ9e9qZmUL1LYpCzESbXo=
+github.com/Keyfactor/keyfactor-go-client/v3 v3.2.0-rc.5/go.mod h1:a7voCNCgvf+TbQxEno/xQ3wRJ+wlJRJKruhNco50GV8=
 github.com/Netflix/go-expect v0.0.0-20220104043353-73e0943537d2 h1:+vx7roKuyA63nhn5WAunQHLTznkw5W8b1Xc0dNjp83s=
 github.com/Netflix/go-expect v0.0.0-20220104043353-73e0943537d2/go.mod h1:HBCaDeC1lPdgDeDbhX8XFpy1jqjK0IBG8W5K+xYqA0w=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=


### PR DESCRIPTION
- preserve inventory schedules on stores that are targeted
- migrate Store Password when present when using PAM
  - preserve Store Password field in all other cases