### PR TITLE
docs(auth): document OAuth client-credentials & Entra ID (3rd-party IdP) setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,10 +92,44 @@ Currently `Basic Authentication` via `Active Directory` is the *ONLY* supported 
 | KEYFACTOR_AUTH_CLIENT_ID     | Keyfactor Auth Client ID                                                                                                        |          |
 | KEYFACTOR_AUTH_CLIENT_SECRET | Keyfactor Auth Client Secret                                                                                                    |          |
 | KEYFACTOR_AUTH_TOKEN_URL     | URL to request an access token from Keyfactor Auth                                                                              |          |
-| KEYFACTOR_AUTH_SCOPES        | Scopes to request when authenticating to Keyfactor Command API. Each scope MUST be separated by `,`                             | `openid` |
-| KEYFACTOR_AUTH_AUDIENCE      | Audience to request when authenticating to Keyfactor Command API                                                                |          |
+| KEYFACTOR_AUTH_SCOPES        | Scopes to request when authenticating to Keyfactor Command API. Multiple scopes MUST be separated by `,` (comma)                | _(none)_ |
+| KEYFACTOR_AUTH_AUDIENCE      | Audience to request when authenticating to Keyfactor Command API. Sent as the `audience` form parameter. Leave unset for Microsoft Entra ID (see below) |          |
 | KEYFACTOR_AUTH_ACCESS_TOKEN  | Access token to use to authenticate to Keyfactor Command API. This can be supplied directly or generated via client credentials |          |
 | KEYFACTOR_AUTH_CA_CERT       | Either a file path or PEM encoded string to a CA certificate to use when connecting to Keyfactor Auth                           |          |
+
+`kfutil` supports two oAuth2 grant types:
+
+- **Client Credentials** — `kfutil` exchanges a `client_id` and `client_secret` at the `token_url` for an
+  access token. This is the most common configuration.
+- **Static Access Token** — you supply a previously obtained access token directly via `KEYFACTOR_AUTH_ACCESS_TOKEN`.
+
+The interactive authorization-code / PKCE grant is **not** supported.
+
+#### Third-party IdP (Microsoft Entra ID / Azure AD)
+
+`kfutil` is not limited to the Keyfactor-hosted Keycloak IdP. Because the token endpoint (`token_url`) and
+`scopes` are fully configurable, you can authenticate against any OAuth2 IdP that Keyfactor Command trusts,
+including **Microsoft Entra ID** (formerly Azure AD).
+
+The Entra-side setup (registering the Command API application, exposing an API / Application ID URI, and
+granting the calling application permission to it) is documented in the Keyfactor Command / Entra SSO
+documentation and is a prerequisite for the steps below. Once that is in place, configure `kfutil` as follows:
+
+- **`token_url`** must point at the Entra v2.0 token endpoint for your tenant:
+  `https://login.microsoftonline.com/<tenant-id>/oauth2/v2.0/token`
+- **`client_id`** / **`client_secret`** are the Entra app registration's *Application (client) ID* and a
+  *client secret* generated for it.
+- **`scopes`** is **mandatory** for Entra and must be `api://<command-app-id-uri>/.default`. `kfutil` does not
+  send any scope by default, so a request with no scope configured will be rejected by Entra.
+  When using the `KEYFACTOR_AUTH_SCOPES` environment variable, supply exactly **one** scope with **no commas**
+  (the value is split on `,`).
+- **`audience`** must be **left unset** for Entra. Entra does not accept an `audience` form parameter; the
+  target resource is encoded inside the `.default` scope instead.
+
+> **Scope vs. audience — the key distinction:** Some IdPs (such as Keycloak) identify the target resource via
+> an `audience` parameter. Entra ID does **not**; it derives the resource from the requested scope
+> (`api://<command-app-id-uri>/.default`). If you set `audience` when authenticating against Entra, the token
+> request will fail. Use `scopes` for Entra and leave `audience` empty.
 
 ### kfutil specific
 
@@ -139,6 +173,19 @@ This is the minimum required configuration to authenticate to Keyfactor Command 
 ```bash
 export KEYFACTOR_HOSTNAME="<mykeyfactorhost.mydomain.com>"
 export KEYFACTOR_AUTH_ACCESS_TOKEN="<my-access-token>"
+```
+
+#### oAuth Client Credentials with Microsoft Entra ID (Azure AD)
+
+This authenticates to Keyfactor Command using an Entra ID app registration. Note the Entra v2.0 `token_url`,
+the mandatory `.default` scope, and that `KEYFACTOR_AUTH_AUDIENCE` is intentionally **not** set.
+```bash
+export KEYFACTOR_HOSTNAME="<mykeyfactorhost.mydomain.com>"
+export KEYFACTOR_AUTH_CLIENT_ID="<entra-app-client-id>"
+export KEYFACTOR_AUTH_CLIENT_SECRET="<entra-client-secret>"
+export KEYFACTOR_AUTH_TOKEN_URL="https://login.microsoftonline.com/<tenant-id>/oauth2/v2.0/token"
+export KEYFACTOR_AUTH_SCOPES="api://<command-app-id-uri>/.default"
+# Do NOT set KEYFACTOR_AUTH_AUDIENCE for Entra ID
 ```
 
 #### Additional variables
@@ -185,6 +232,20 @@ This is the minimum required configuration to authenticate to Keyfactor Command 
 ```powershell
 $env:KEYFACTOR_HOSTNAME = "<mykeyfactorhost.mydomain.com>"
 $env:KEYFACTOR_AUTH_ACCESS_TOKEN = "<my-access-token>"
+```
+
+#### oAuth Client Credentials with Microsoft Entra ID (Azure AD)
+
+This authenticates to Keyfactor Command using an Entra ID app registration. Note the Entra v2.0 token URL,
+the mandatory `.default` scope, and that `KEYFACTOR_AUTH_AUDIENCE` is intentionally **not** set.
+
+```powershell
+$env:KEYFACTOR_HOSTNAME = "<mykeyfactorhost.mydomain.com>"
+$env:KEYFACTOR_AUTH_CLIENT_ID = "<entra-app-client-id>"
+$env:KEYFACTOR_AUTH_CLIENT_SECRET = "<entra-client-secret>"
+$env:KEYFACTOR_AUTH_TOKEN_URL = "https://login.microsoftonline.com/<tenant-id>/oauth2/v2.0/token"
+$env:KEYFACTOR_AUTH_SCOPES = "api://<command-app-id-uri>/.default"
+# Do NOT set KEYFACTOR_AUTH_AUDIENCE for Entra ID
 ```
 
 #### Additional variables:

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1023,7 +1023,7 @@ func init() {
 	)
 
 	RootCmd.PersistentFlags().StringVarP(
-		&kfcClientId,
+		&kfcTokenUrl,
 		"token-url",
 		"",
 		"",

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -52,6 +52,8 @@ var (
 	kfcClientSecret string
 	kfcTokenUrl     string
 	kfcAPIPath      string
+	kfcScopes       string
+	kfcAudience     string
 	logInsecure     bool
 	outputFormat    string
 	offline         bool
@@ -148,6 +150,46 @@ func getServerConfigFromEnv() (*auth_providers.Server, error) {
 	tokenUrl, tOk := os.LookupEnv(auth_providers.EnvKeyfactorAuthTokenURL)
 	skipVerify, svOk := os.LookupEnv(auth_providers.EnvKeyfactorSkipVerify)
 	var skipVerifyBool bool
+
+	// CLI persistent flags, when explicitly provided, take precedence over environment
+	// variables. Changed() is used (rather than a non-empty check) so that flags with a
+	// non-empty default (e.g. --api-path) do not silently override an environment value
+	// the user did set.
+	authFlags := RootCmd.PersistentFlags()
+	if authFlags.Changed("username") {
+		username, uOk = kfcUsername, true
+	}
+	if authFlags.Changed("password") {
+		password, pOk = kfcPassword, true
+	}
+	if authFlags.Changed("domain") {
+		domain, dOk = kfcDomain, true
+	}
+	if authFlags.Changed("hostname") {
+		hostname, hOk = kfcHostName, true
+	}
+	if authFlags.Changed("api-path") {
+		apiPath, aOk = kfcAPIPath, true
+	}
+	if authFlags.Changed("client-id") {
+		clientId, cOk = kfcClientId, true
+	}
+	if authFlags.Changed("client-secret") {
+		clientSecret, csOk = kfcClientSecret, true
+	}
+	if authFlags.Changed("token-url") {
+		tokenUrl, tOk = kfcTokenUrl, true
+	}
+	if authFlags.Changed("audience") {
+		audience = kfcAudience
+	}
+	if authFlags.Changed("scopes") {
+		if kfcScopes != "" {
+			scopes = strings.Split(kfcScopes, ",")
+		} else {
+			scopes = nil
+		}
+	}
 
 	isBasicAuth := uOk && pOk
 	isOAuth := cOk && csOk && tOk
@@ -1057,6 +1099,20 @@ func init() {
 		"",
 		"KeyfactorAPI",
 		"API Path to use for authenticating to Keyfactor Command. (default is KeyfactorAPI)",
+	)
+	RootCmd.PersistentFlags().StringVarP(
+		&kfcScopes,
+		"scopes",
+		"",
+		"",
+		"Comma-separated list of OAuth2 scopes to request when authenticating via a third-party IdP (e.g. Entra ID: api://<app-id-uri>/.default).",
+	)
+	RootCmd.PersistentFlags().StringVarP(
+		&kfcAudience,
+		"audience",
+		"",
+		"",
+		"OAuth2 audience to request when authenticating to Keyfactor Command. Not used by all IdPs (e.g. leave unset for Entra ID).",
 	)
 
 	// Cobra also supports local flags, which will only run

--- a/docs/auth_providers.md
+++ b/docs/auth_providers.md
@@ -73,6 +73,53 @@ interactive auth flow. Here's an example of what that would look like:
 }
 ```
 
+#### oAuth Client Credentials with a Third-party IdP (Microsoft Entra ID / Azure AD)
+
+`kfutil` can authenticate against any OAuth2 IdP that Keyfactor Command trusts, not only the Keyfactor-hosted
+Keycloak. The example below configures **Microsoft Entra ID** (formerly Azure AD) using the client-credentials
+grant. The Entra-side setup — registering the Command API application, exposing its API / Application ID URI,
+and granting the calling app permission — lives in the Keyfactor Command / Entra SSO documentation and is a
+prerequisite.
+
+```json
+{
+  "servers": {
+    "default": {
+      "host": "keyfactor.example.com",
+      "auth_type": "oauth",
+      "client_id": "<entra-app-client-id>",
+      "client_secret": "<entra-client-secret>",
+      "token_url": "https://login.microsoftonline.com/<tenant-id>/oauth2/v2.0/token",
+      "scopes": ["api://<command-app-id-uri>/.default"],
+      "api_path": "KeyfactorAPI"
+    }
+  }
+}
+```
+
+Key points when targeting Entra ID:
+
+- **`token_url`** is the Entra v2.0 token endpoint for your tenant:
+  `https://login.microsoftonline.com/<tenant-id>/oauth2/v2.0/token`.
+- **`client_id`** / **`client_secret`** are the Entra app registration's *Application (client) ID* and a
+  generated *client secret*.
+- **`scopes`** is **mandatory** and must be `api://<command-app-id-uri>/.default`. `kfutil` sends no scope by
+  default, so an Entra request with no scope configured is rejected.
+- **`audience`** must be **omitted**. Entra ID does not accept an `audience` form parameter.
+
+##### Scope vs. audience
+
+This is the most common point of confusion when moving from Keycloak to Entra ID:
+
+- **Keycloak** (the Keyfactor-hosted IdP) identifies the target resource with the `audience` field, and scopes
+  are typically optional.
+- **Entra ID** identifies the target resource through the requested **scope** (`api://<command-app-id-uri>/.default`)
+  and does **not** support an `audience` parameter.
+
+Therefore, for Entra ID set `scopes` and leave `audience` unset. Setting `audience` against Entra will cause the
+token request to fail. Note also that the `KEYFACTOR_AUTH_SCOPES` environment variable is split on `,` (comma),
+so when using env vars supply exactly one Entra scope with no commas.
+
 #### Usage
 
 ##### Default

--- a/docs/kfutil.md
+++ b/docs/kfutil.md
@@ -10,6 +10,7 @@ A CLI wrapper around the Keyfactor Platform API.
 
 ```
       --api-path string                API Path to use for authenticating to Keyfactor Command. (default is KeyfactorAPI) (default "KeyfactorAPI")
+      --audience string                OAuth2 audience to request when authenticating to Keyfactor Command. Not used by all IdPs (e.g. leave unset for Entra ID).
       --auth-provider-profile string   The profile to use defined in the securely stored config. If not specified the config named 'default' will be used if it exists. (default "default")
       --auth-provider-type string      Provider type choices: (azid)
       --client-id string               OAuth2 client-id to use for authenticating to Keyfactor Command.
@@ -25,6 +26,7 @@ A CLI wrapper around the Keyfactor Platform API.
       --offline                        Will not attempt to connect to GitHub for latest release information and resources.
       --password string                Password to use for authenticating to Keyfactor Command. WARNING: Remember to delete your console history if providing kfcPassword here in plain text.
       --profile string                 Use a specific profile from your config file. If not specified the config named 'default' will be used if it exists.
+      --scopes string                  Comma-separated list of OAuth2 scopes to request when authenticating via a third-party IdP (e.g. Entra ID: api://<app-id-uri>/.default).
       --skip-tls-verify                Disable TLS verification for API requests to Keyfactor Command.
       --token-url string               OAuth2 token endpoint full URL to use for authenticating to Keyfactor Command.
       --username string                Username to use for authenticating to Keyfactor Command.

--- a/docs/kfutil_completion.md
+++ b/docs/kfutil_completion.md
@@ -18,6 +18,7 @@ See each sub-command's help for details on how to use the generated script.
 
 ```
       --api-path string                API Path to use for authenticating to Keyfactor Command. (default is KeyfactorAPI) (default "KeyfactorAPI")
+      --audience string                OAuth2 audience to request when authenticating to Keyfactor Command. Not used by all IdPs (e.g. leave unset for Entra ID).
       --auth-provider-profile string   The profile to use defined in the securely stored config. If not specified the config named 'default' will be used if it exists. (default "default")
       --auth-provider-type string      Provider type choices: (azid)
       --client-id string               OAuth2 client-id to use for authenticating to Keyfactor Command.
@@ -32,6 +33,7 @@ See each sub-command's help for details on how to use the generated script.
       --offline                        Will not attempt to connect to GitHub for latest release information and resources.
       --password string                Password to use for authenticating to Keyfactor Command. WARNING: Remember to delete your console history if providing kfcPassword here in plain text.
       --profile string                 Use a specific profile from your config file. If not specified the config named 'default' will be used if it exists.
+      --scopes string                  Comma-separated list of OAuth2 scopes to request when authenticating via a third-party IdP (e.g. Entra ID: api://<app-id-uri>/.default).
       --skip-tls-verify                Disable TLS verification for API requests to Keyfactor Command.
       --token-url string               OAuth2 token endpoint full URL to use for authenticating to Keyfactor Command.
       --username string                Username to use for authenticating to Keyfactor Command.

--- a/docs/kfutil_completion_bash.md
+++ b/docs/kfutil_completion_bash.md
@@ -41,6 +41,7 @@ kfutil completion bash
 
 ```
       --api-path string                API Path to use for authenticating to Keyfactor Command. (default is KeyfactorAPI) (default "KeyfactorAPI")
+      --audience string                OAuth2 audience to request when authenticating to Keyfactor Command. Not used by all IdPs (e.g. leave unset for Entra ID).
       --auth-provider-profile string   The profile to use defined in the securely stored config. If not specified the config named 'default' will be used if it exists. (default "default")
       --auth-provider-type string      Provider type choices: (azid)
       --client-id string               OAuth2 client-id to use for authenticating to Keyfactor Command.
@@ -55,6 +56,7 @@ kfutil completion bash
       --offline                        Will not attempt to connect to GitHub for latest release information and resources.
       --password string                Password to use for authenticating to Keyfactor Command. WARNING: Remember to delete your console history if providing kfcPassword here in plain text.
       --profile string                 Use a specific profile from your config file. If not specified the config named 'default' will be used if it exists.
+      --scopes string                  Comma-separated list of OAuth2 scopes to request when authenticating via a third-party IdP (e.g. Entra ID: api://<app-id-uri>/.default).
       --skip-tls-verify                Disable TLS verification for API requests to Keyfactor Command.
       --token-url string               OAuth2 token endpoint full URL to use for authenticating to Keyfactor Command.
       --username string                Username to use for authenticating to Keyfactor Command.

--- a/docs/kfutil_completion_fish.md
+++ b/docs/kfutil_completion_fish.md
@@ -32,6 +32,7 @@ kfutil completion fish [flags]
 
 ```
       --api-path string                API Path to use for authenticating to Keyfactor Command. (default is KeyfactorAPI) (default "KeyfactorAPI")
+      --audience string                OAuth2 audience to request when authenticating to Keyfactor Command. Not used by all IdPs (e.g. leave unset for Entra ID).
       --auth-provider-profile string   The profile to use defined in the securely stored config. If not specified the config named 'default' will be used if it exists. (default "default")
       --auth-provider-type string      Provider type choices: (azid)
       --client-id string               OAuth2 client-id to use for authenticating to Keyfactor Command.
@@ -46,6 +47,7 @@ kfutil completion fish [flags]
       --offline                        Will not attempt to connect to GitHub for latest release information and resources.
       --password string                Password to use for authenticating to Keyfactor Command. WARNING: Remember to delete your console history if providing kfcPassword here in plain text.
       --profile string                 Use a specific profile from your config file. If not specified the config named 'default' will be used if it exists.
+      --scopes string                  Comma-separated list of OAuth2 scopes to request when authenticating via a third-party IdP (e.g. Entra ID: api://<app-id-uri>/.default).
       --skip-tls-verify                Disable TLS verification for API requests to Keyfactor Command.
       --token-url string               OAuth2 token endpoint full URL to use for authenticating to Keyfactor Command.
       --username string                Username to use for authenticating to Keyfactor Command.

--- a/docs/kfutil_completion_powershell.md
+++ b/docs/kfutil_completion_powershell.md
@@ -29,6 +29,7 @@ kfutil completion powershell [flags]
 
 ```
       --api-path string                API Path to use for authenticating to Keyfactor Command. (default is KeyfactorAPI) (default "KeyfactorAPI")
+      --audience string                OAuth2 audience to request when authenticating to Keyfactor Command. Not used by all IdPs (e.g. leave unset for Entra ID).
       --auth-provider-profile string   The profile to use defined in the securely stored config. If not specified the config named 'default' will be used if it exists. (default "default")
       --auth-provider-type string      Provider type choices: (azid)
       --client-id string               OAuth2 client-id to use for authenticating to Keyfactor Command.
@@ -43,6 +44,7 @@ kfutil completion powershell [flags]
       --offline                        Will not attempt to connect to GitHub for latest release information and resources.
       --password string                Password to use for authenticating to Keyfactor Command. WARNING: Remember to delete your console history if providing kfcPassword here in plain text.
       --profile string                 Use a specific profile from your config file. If not specified the config named 'default' will be used if it exists.
+      --scopes string                  Comma-separated list of OAuth2 scopes to request when authenticating via a third-party IdP (e.g. Entra ID: api://<app-id-uri>/.default).
       --skip-tls-verify                Disable TLS verification for API requests to Keyfactor Command.
       --token-url string               OAuth2 token endpoint full URL to use for authenticating to Keyfactor Command.
       --username string                Username to use for authenticating to Keyfactor Command.

--- a/docs/kfutil_completion_zsh.md
+++ b/docs/kfutil_completion_zsh.md
@@ -43,6 +43,7 @@ kfutil completion zsh [flags]
 
 ```
       --api-path string                API Path to use for authenticating to Keyfactor Command. (default is KeyfactorAPI) (default "KeyfactorAPI")
+      --audience string                OAuth2 audience to request when authenticating to Keyfactor Command. Not used by all IdPs (e.g. leave unset for Entra ID).
       --auth-provider-profile string   The profile to use defined in the securely stored config. If not specified the config named 'default' will be used if it exists. (default "default")
       --auth-provider-type string      Provider type choices: (azid)
       --client-id string               OAuth2 client-id to use for authenticating to Keyfactor Command.
@@ -57,6 +58,7 @@ kfutil completion zsh [flags]
       --offline                        Will not attempt to connect to GitHub for latest release information and resources.
       --password string                Password to use for authenticating to Keyfactor Command. WARNING: Remember to delete your console history if providing kfcPassword here in plain text.
       --profile string                 Use a specific profile from your config file. If not specified the config named 'default' will be used if it exists.
+      --scopes string                  Comma-separated list of OAuth2 scopes to request when authenticating via a third-party IdP (e.g. Entra ID: api://<app-id-uri>/.default).
       --skip-tls-verify                Disable TLS verification for API requests to Keyfactor Command.
       --token-url string               OAuth2 token endpoint full URL to use for authenticating to Keyfactor Command.
       --username string                Username to use for authenticating to Keyfactor Command.

--- a/docs/kfutil_containers.md
+++ b/docs/kfutil_containers.md
@@ -16,6 +16,7 @@ A collections of APIs and utilities for interacting with Keyfactor certificate s
 
 ```
       --api-path string                API Path to use for authenticating to Keyfactor Command. (default is KeyfactorAPI) (default "KeyfactorAPI")
+      --audience string                OAuth2 audience to request when authenticating to Keyfactor Command. Not used by all IdPs (e.g. leave unset for Entra ID).
       --auth-provider-profile string   The profile to use defined in the securely stored config. If not specified the config named 'default' will be used if it exists. (default "default")
       --auth-provider-type string      Provider type choices: (azid)
       --client-id string               OAuth2 client-id to use for authenticating to Keyfactor Command.
@@ -30,6 +31,7 @@ A collections of APIs and utilities for interacting with Keyfactor certificate s
       --offline                        Will not attempt to connect to GitHub for latest release information and resources.
       --password string                Password to use for authenticating to Keyfactor Command. WARNING: Remember to delete your console history if providing kfcPassword here in plain text.
       --profile string                 Use a specific profile from your config file. If not specified the config named 'default' will be used if it exists.
+      --scopes string                  Comma-separated list of OAuth2 scopes to request when authenticating via a third-party IdP (e.g. Entra ID: api://<app-id-uri>/.default).
       --skip-tls-verify                Disable TLS verification for API requests to Keyfactor Command.
       --token-url string               OAuth2 token endpoint full URL to use for authenticating to Keyfactor Command.
       --username string                Username to use for authenticating to Keyfactor Command.

--- a/docs/kfutil_containers_get.md
+++ b/docs/kfutil_containers_get.md
@@ -21,6 +21,7 @@ kfutil containers get [flags]
 
 ```
       --api-path string                API Path to use for authenticating to Keyfactor Command. (default is KeyfactorAPI) (default "KeyfactorAPI")
+      --audience string                OAuth2 audience to request when authenticating to Keyfactor Command. Not used by all IdPs (e.g. leave unset for Entra ID).
       --auth-provider-profile string   The profile to use defined in the securely stored config. If not specified the config named 'default' will be used if it exists. (default "default")
       --auth-provider-type string      Provider type choices: (azid)
       --client-id string               OAuth2 client-id to use for authenticating to Keyfactor Command.
@@ -35,6 +36,7 @@ kfutil containers get [flags]
       --offline                        Will not attempt to connect to GitHub for latest release information and resources.
       --password string                Password to use for authenticating to Keyfactor Command. WARNING: Remember to delete your console history if providing kfcPassword here in plain text.
       --profile string                 Use a specific profile from your config file. If not specified the config named 'default' will be used if it exists.
+      --scopes string                  Comma-separated list of OAuth2 scopes to request when authenticating via a third-party IdP (e.g. Entra ID: api://<app-id-uri>/.default).
       --skip-tls-verify                Disable TLS verification for API requests to Keyfactor Command.
       --token-url string               OAuth2 token endpoint full URL to use for authenticating to Keyfactor Command.
       --username string                Username to use for authenticating to Keyfactor Command.

--- a/docs/kfutil_containers_list.md
+++ b/docs/kfutil_containers_list.md
@@ -20,6 +20,7 @@ kfutil containers list [flags]
 
 ```
       --api-path string                API Path to use for authenticating to Keyfactor Command. (default is KeyfactorAPI) (default "KeyfactorAPI")
+      --audience string                OAuth2 audience to request when authenticating to Keyfactor Command. Not used by all IdPs (e.g. leave unset for Entra ID).
       --auth-provider-profile string   The profile to use defined in the securely stored config. If not specified the config named 'default' will be used if it exists. (default "default")
       --auth-provider-type string      Provider type choices: (azid)
       --client-id string               OAuth2 client-id to use for authenticating to Keyfactor Command.
@@ -34,6 +35,7 @@ kfutil containers list [flags]
       --offline                        Will not attempt to connect to GitHub for latest release information and resources.
       --password string                Password to use for authenticating to Keyfactor Command. WARNING: Remember to delete your console history if providing kfcPassword here in plain text.
       --profile string                 Use a specific profile from your config file. If not specified the config named 'default' will be used if it exists.
+      --scopes string                  Comma-separated list of OAuth2 scopes to request when authenticating via a third-party IdP (e.g. Entra ID: api://<app-id-uri>/.default).
       --skip-tls-verify                Disable TLS verification for API requests to Keyfactor Command.
       --token-url string               OAuth2 token endpoint full URL to use for authenticating to Keyfactor Command.
       --username string                Username to use for authenticating to Keyfactor Command.

--- a/docs/kfutil_export.md
+++ b/docs/kfutil_export.md
@@ -32,6 +32,7 @@ kfutil export [flags]
 
 ```
       --api-path string                API Path to use for authenticating to Keyfactor Command. (default is KeyfactorAPI) (default "KeyfactorAPI")
+      --audience string                OAuth2 audience to request when authenticating to Keyfactor Command. Not used by all IdPs (e.g. leave unset for Entra ID).
       --auth-provider-profile string   The profile to use defined in the securely stored config. If not specified the config named 'default' will be used if it exists. (default "default")
       --auth-provider-type string      Provider type choices: (azid)
       --client-id string               OAuth2 client-id to use for authenticating to Keyfactor Command.
@@ -46,6 +47,7 @@ kfutil export [flags]
       --offline                        Will not attempt to connect to GitHub for latest release information and resources.
       --password string                Password to use for authenticating to Keyfactor Command. WARNING: Remember to delete your console history if providing kfcPassword here in plain text.
       --profile string                 Use a specific profile from your config file. If not specified the config named 'default' will be used if it exists.
+      --scopes string                  Comma-separated list of OAuth2 scopes to request when authenticating via a third-party IdP (e.g. Entra ID: api://<app-id-uri>/.default).
       --skip-tls-verify                Disable TLS verification for API requests to Keyfactor Command.
       --token-url string               OAuth2 token endpoint full URL to use for authenticating to Keyfactor Command.
       --username string                Username to use for authenticating to Keyfactor Command.

--- a/docs/kfutil_helm.md
+++ b/docs/kfutil_helm.md
@@ -22,6 +22,7 @@ kubectl helm uo | helm install -f - keyfactor-universal-orchestrator keyfactor/k
 
 ```
       --api-path string                API Path to use for authenticating to Keyfactor Command. (default is KeyfactorAPI) (default "KeyfactorAPI")
+      --audience string                OAuth2 audience to request when authenticating to Keyfactor Command. Not used by all IdPs (e.g. leave unset for Entra ID).
       --auth-provider-profile string   The profile to use defined in the securely stored config. If not specified the config named 'default' will be used if it exists. (default "default")
       --auth-provider-type string      Provider type choices: (azid)
       --client-id string               OAuth2 client-id to use for authenticating to Keyfactor Command.
@@ -36,6 +37,7 @@ kubectl helm uo | helm install -f - keyfactor-universal-orchestrator keyfactor/k
       --offline                        Will not attempt to connect to GitHub for latest release information and resources.
       --password string                Password to use for authenticating to Keyfactor Command. WARNING: Remember to delete your console history if providing kfcPassword here in plain text.
       --profile string                 Use a specific profile from your config file. If not specified the config named 'default' will be used if it exists.
+      --scopes string                  Comma-separated list of OAuth2 scopes to request when authenticating via a third-party IdP (e.g. Entra ID: api://<app-id-uri>/.default).
       --skip-tls-verify                Disable TLS verification for API requests to Keyfactor Command.
       --token-url string               OAuth2 token endpoint full URL to use for authenticating to Keyfactor Command.
       --username string                Username to use for authenticating to Keyfactor Command.

--- a/docs/kfutil_helm_uo.md
+++ b/docs/kfutil_helm_uo.md
@@ -27,6 +27,7 @@ kfutil helm uo [-t <token>] [-o <path>] [-f <file, url, or '-'>] [-e <extension 
 
 ```
       --api-path string                API Path to use for authenticating to Keyfactor Command. (default is KeyfactorAPI) (default "KeyfactorAPI")
+      --audience string                OAuth2 audience to request when authenticating to Keyfactor Command. Not used by all IdPs (e.g. leave unset for Entra ID).
       --auth-provider-profile string   The profile to use defined in the securely stored config. If not specified the config named 'default' will be used if it exists. (default "default")
       --auth-provider-type string      Provider type choices: (azid)
       --client-id string               OAuth2 client-id to use for authenticating to Keyfactor Command.
@@ -41,6 +42,7 @@ kfutil helm uo [-t <token>] [-o <path>] [-f <file, url, or '-'>] [-e <extension 
       --offline                        Will not attempt to connect to GitHub for latest release information and resources.
       --password string                Password to use for authenticating to Keyfactor Command. WARNING: Remember to delete your console history if providing kfcPassword here in plain text.
       --profile string                 Use a specific profile from your config file. If not specified the config named 'default' will be used if it exists.
+      --scopes string                  Comma-separated list of OAuth2 scopes to request when authenticating via a third-party IdP (e.g. Entra ID: api://<app-id-uri>/.default).
       --skip-tls-verify                Disable TLS verification for API requests to Keyfactor Command.
       --token-url string               OAuth2 token endpoint full URL to use for authenticating to Keyfactor Command.
       --username string                Username to use for authenticating to Keyfactor Command.

--- a/docs/kfutil_import.md
+++ b/docs/kfutil_import.md
@@ -31,6 +31,7 @@ kfutil import [flags]
 
 ```
       --api-path string                API Path to use for authenticating to Keyfactor Command. (default is KeyfactorAPI) (default "KeyfactorAPI")
+      --audience string                OAuth2 audience to request when authenticating to Keyfactor Command. Not used by all IdPs (e.g. leave unset for Entra ID).
       --auth-provider-profile string   The profile to use defined in the securely stored config. If not specified the config named 'default' will be used if it exists. (default "default")
       --auth-provider-type string      Provider type choices: (azid)
       --client-id string               OAuth2 client-id to use for authenticating to Keyfactor Command.
@@ -45,6 +46,7 @@ kfutil import [flags]
       --offline                        Will not attempt to connect to GitHub for latest release information and resources.
       --password string                Password to use for authenticating to Keyfactor Command. WARNING: Remember to delete your console history if providing kfcPassword here in plain text.
       --profile string                 Use a specific profile from your config file. If not specified the config named 'default' will be used if it exists.
+      --scopes string                  Comma-separated list of OAuth2 scopes to request when authenticating via a third-party IdP (e.g. Entra ID: api://<app-id-uri>/.default).
       --skip-tls-verify                Disable TLS verification for API requests to Keyfactor Command.
       --token-url string               OAuth2 token endpoint full URL to use for authenticating to Keyfactor Command.
       --username string                Username to use for authenticating to Keyfactor Command.

--- a/docs/kfutil_login.md
+++ b/docs/kfutil_login.md
@@ -31,6 +31,7 @@ kfutil login [flags]
 
 ```
       --api-path string                API Path to use for authenticating to Keyfactor Command. (default is KeyfactorAPI) (default "KeyfactorAPI")
+      --audience string                OAuth2 audience to request when authenticating to Keyfactor Command. Not used by all IdPs (e.g. leave unset for Entra ID).
       --auth-provider-profile string   The profile to use defined in the securely stored config. If not specified the config named 'default' will be used if it exists. (default "default")
       --auth-provider-type string      Provider type choices: (azid)
       --client-id string               OAuth2 client-id to use for authenticating to Keyfactor Command.
@@ -45,6 +46,7 @@ kfutil login [flags]
       --offline                        Will not attempt to connect to GitHub for latest release information and resources.
       --password string                Password to use for authenticating to Keyfactor Command. WARNING: Remember to delete your console history if providing kfcPassword here in plain text.
       --profile string                 Use a specific profile from your config file. If not specified the config named 'default' will be used if it exists.
+      --scopes string                  Comma-separated list of OAuth2 scopes to request when authenticating via a third-party IdP (e.g. Entra ID: api://<app-id-uri>/.default).
       --skip-tls-verify                Disable TLS verification for API requests to Keyfactor Command.
       --token-url string               OAuth2 token endpoint full URL to use for authenticating to Keyfactor Command.
       --username string                Username to use for authenticating to Keyfactor Command.

--- a/docs/kfutil_logout.md
+++ b/docs/kfutil_logout.md
@@ -20,6 +20,7 @@ kfutil logout [flags]
 
 ```
       --api-path string                API Path to use for authenticating to Keyfactor Command. (default is KeyfactorAPI) (default "KeyfactorAPI")
+      --audience string                OAuth2 audience to request when authenticating to Keyfactor Command. Not used by all IdPs (e.g. leave unset for Entra ID).
       --auth-provider-profile string   The profile to use defined in the securely stored config. If not specified the config named 'default' will be used if it exists. (default "default")
       --auth-provider-type string      Provider type choices: (azid)
       --client-id string               OAuth2 client-id to use for authenticating to Keyfactor Command.
@@ -34,6 +35,7 @@ kfutil logout [flags]
       --offline                        Will not attempt to connect to GitHub for latest release information and resources.
       --password string                Password to use for authenticating to Keyfactor Command. WARNING: Remember to delete your console history if providing kfcPassword here in plain text.
       --profile string                 Use a specific profile from your config file. If not specified the config named 'default' will be used if it exists.
+      --scopes string                  Comma-separated list of OAuth2 scopes to request when authenticating via a third-party IdP (e.g. Entra ID: api://<app-id-uri>/.default).
       --skip-tls-verify                Disable TLS verification for API requests to Keyfactor Command.
       --token-url string               OAuth2 token endpoint full URL to use for authenticating to Keyfactor Command.
       --username string                Username to use for authenticating to Keyfactor Command.

--- a/docs/kfutil_migrate.md
+++ b/docs/kfutil_migrate.md
@@ -18,6 +18,7 @@ Migrating to new Types and Extension implementations in Keyfactor is possible bu
 
 ```
       --api-path string                API Path to use for authenticating to Keyfactor Command. (default is KeyfactorAPI) (default "KeyfactorAPI")
+      --audience string                OAuth2 audience to request when authenticating to Keyfactor Command. Not used by all IdPs (e.g. leave unset for Entra ID).
       --auth-provider-profile string   The profile to use defined in the securely stored config. If not specified the config named 'default' will be used if it exists. (default "default")
       --auth-provider-type string      Provider type choices: (azid)
       --client-id string               OAuth2 client-id to use for authenticating to Keyfactor Command.
@@ -32,6 +33,7 @@ Migrating to new Types and Extension implementations in Keyfactor is possible bu
       --offline                        Will not attempt to connect to GitHub for latest release information and resources.
       --password string                Password to use for authenticating to Keyfactor Command. WARNING: Remember to delete your console history if providing kfcPassword here in plain text.
       --profile string                 Use a specific profile from your config file. If not specified the config named 'default' will be used if it exists.
+      --scopes string                  Comma-separated list of OAuth2 scopes to request when authenticating via a third-party IdP (e.g. Entra ID: api://<app-id-uri>/.default).
       --skip-tls-verify                Disable TLS verification for API requests to Keyfactor Command.
       --token-url string               OAuth2 token endpoint full URL to use for authenticating to Keyfactor Command.
       --username string                Username to use for authenticating to Keyfactor Command.

--- a/docs/kfutil_migrate_check.md
+++ b/docs/kfutil_migrate_check.md
@@ -22,6 +22,7 @@ kfutil migrate check [flags]
 
 ```
       --api-path string                API Path to use for authenticating to Keyfactor Command. (default is KeyfactorAPI) (default "KeyfactorAPI")
+      --audience string                OAuth2 audience to request when authenticating to Keyfactor Command. Not used by all IdPs (e.g. leave unset for Entra ID).
       --auth-provider-profile string   The profile to use defined in the securely stored config. If not specified the config named 'default' will be used if it exists. (default "default")
       --auth-provider-type string      Provider type choices: (azid)
       --client-id string               OAuth2 client-id to use for authenticating to Keyfactor Command.
@@ -36,6 +37,7 @@ kfutil migrate check [flags]
       --offline                        Will not attempt to connect to GitHub for latest release information and resources.
       --password string                Password to use for authenticating to Keyfactor Command. WARNING: Remember to delete your console history if providing kfcPassword here in plain text.
       --profile string                 Use a specific profile from your config file. If not specified the config named 'default' will be used if it exists.
+      --scopes string                  Comma-separated list of OAuth2 scopes to request when authenticating via a third-party IdP (e.g. Entra ID: api://<app-id-uri>/.default).
       --skip-tls-verify                Disable TLS verification for API requests to Keyfactor Command.
       --token-url string               OAuth2 token endpoint full URL to use for authenticating to Keyfactor Command.
       --username string                Username to use for authenticating to Keyfactor Command.

--- a/docs/kfutil_migrate_pam.md
+++ b/docs/kfutil_migrate_pam.md
@@ -24,6 +24,7 @@ kfutil migrate pam [flags]
 
 ```
       --api-path string                API Path to use for authenticating to Keyfactor Command. (default is KeyfactorAPI) (default "KeyfactorAPI")
+      --audience string                OAuth2 audience to request when authenticating to Keyfactor Command. Not used by all IdPs (e.g. leave unset for Entra ID).
       --auth-provider-profile string   The profile to use defined in the securely stored config. If not specified the config named 'default' will be used if it exists. (default "default")
       --auth-provider-type string      Provider type choices: (azid)
       --client-id string               OAuth2 client-id to use for authenticating to Keyfactor Command.
@@ -38,6 +39,7 @@ kfutil migrate pam [flags]
       --offline                        Will not attempt to connect to GitHub for latest release information and resources.
       --password string                Password to use for authenticating to Keyfactor Command. WARNING: Remember to delete your console history if providing kfcPassword here in plain text.
       --profile string                 Use a specific profile from your config file. If not specified the config named 'default' will be used if it exists.
+      --scopes string                  Comma-separated list of OAuth2 scopes to request when authenticating via a third-party IdP (e.g. Entra ID: api://<app-id-uri>/.default).
       --skip-tls-verify                Disable TLS verification for API requests to Keyfactor Command.
       --token-url string               OAuth2 token endpoint full URL to use for authenticating to Keyfactor Command.
       --username string                Username to use for authenticating to Keyfactor Command.

--- a/docs/kfutil_orchs.md
+++ b/docs/kfutil_orchs.md
@@ -16,6 +16,7 @@ A collections of APIs and utilities for interacting with Keyfactor orchestrators
 
 ```
       --api-path string                API Path to use for authenticating to Keyfactor Command. (default is KeyfactorAPI) (default "KeyfactorAPI")
+      --audience string                OAuth2 audience to request when authenticating to Keyfactor Command. Not used by all IdPs (e.g. leave unset for Entra ID).
       --auth-provider-profile string   The profile to use defined in the securely stored config. If not specified the config named 'default' will be used if it exists. (default "default")
       --auth-provider-type string      Provider type choices: (azid)
       --client-id string               OAuth2 client-id to use for authenticating to Keyfactor Command.
@@ -30,6 +31,7 @@ A collections of APIs and utilities for interacting with Keyfactor orchestrators
       --offline                        Will not attempt to connect to GitHub for latest release information and resources.
       --password string                Password to use for authenticating to Keyfactor Command. WARNING: Remember to delete your console history if providing kfcPassword here in plain text.
       --profile string                 Use a specific profile from your config file. If not specified the config named 'default' will be used if it exists.
+      --scopes string                  Comma-separated list of OAuth2 scopes to request when authenticating via a third-party IdP (e.g. Entra ID: api://<app-id-uri>/.default).
       --skip-tls-verify                Disable TLS verification for API requests to Keyfactor Command.
       --token-url string               OAuth2 token endpoint full URL to use for authenticating to Keyfactor Command.
       --username string                Username to use for authenticating to Keyfactor Command.

--- a/docs/kfutil_orchs_approve.md
+++ b/docs/kfutil_orchs_approve.md
@@ -21,6 +21,7 @@ kfutil orchs approve [flags]
 
 ```
       --api-path string                API Path to use for authenticating to Keyfactor Command. (default is KeyfactorAPI) (default "KeyfactorAPI")
+      --audience string                OAuth2 audience to request when authenticating to Keyfactor Command. Not used by all IdPs (e.g. leave unset for Entra ID).
       --auth-provider-profile string   The profile to use defined in the securely stored config. If not specified the config named 'default' will be used if it exists. (default "default")
       --auth-provider-type string      Provider type choices: (azid)
       --client-id string               OAuth2 client-id to use for authenticating to Keyfactor Command.
@@ -35,6 +36,7 @@ kfutil orchs approve [flags]
       --offline                        Will not attempt to connect to GitHub for latest release information and resources.
       --password string                Password to use for authenticating to Keyfactor Command. WARNING: Remember to delete your console history if providing kfcPassword here in plain text.
       --profile string                 Use a specific profile from your config file. If not specified the config named 'default' will be used if it exists.
+      --scopes string                  Comma-separated list of OAuth2 scopes to request when authenticating via a third-party IdP (e.g. Entra ID: api://<app-id-uri>/.default).
       --skip-tls-verify                Disable TLS verification for API requests to Keyfactor Command.
       --token-url string               OAuth2 token endpoint full URL to use for authenticating to Keyfactor Command.
       --username string                Username to use for authenticating to Keyfactor Command.

--- a/docs/kfutil_orchs_disapprove.md
+++ b/docs/kfutil_orchs_disapprove.md
@@ -21,6 +21,7 @@ kfutil orchs disapprove [flags]
 
 ```
       --api-path string                API Path to use for authenticating to Keyfactor Command. (default is KeyfactorAPI) (default "KeyfactorAPI")
+      --audience string                OAuth2 audience to request when authenticating to Keyfactor Command. Not used by all IdPs (e.g. leave unset for Entra ID).
       --auth-provider-profile string   The profile to use defined in the securely stored config. If not specified the config named 'default' will be used if it exists. (default "default")
       --auth-provider-type string      Provider type choices: (azid)
       --client-id string               OAuth2 client-id to use for authenticating to Keyfactor Command.
@@ -35,6 +36,7 @@ kfutil orchs disapprove [flags]
       --offline                        Will not attempt to connect to GitHub for latest release information and resources.
       --password string                Password to use for authenticating to Keyfactor Command. WARNING: Remember to delete your console history if providing kfcPassword here in plain text.
       --profile string                 Use a specific profile from your config file. If not specified the config named 'default' will be used if it exists.
+      --scopes string                  Comma-separated list of OAuth2 scopes to request when authenticating via a third-party IdP (e.g. Entra ID: api://<app-id-uri>/.default).
       --skip-tls-verify                Disable TLS verification for API requests to Keyfactor Command.
       --token-url string               OAuth2 token endpoint full URL to use for authenticating to Keyfactor Command.
       --username string                Username to use for authenticating to Keyfactor Command.

--- a/docs/kfutil_orchs_ext.md
+++ b/docs/kfutil_orchs_ext.md
@@ -38,6 +38,7 @@ ext -t <token> -e <extension>@<version>,<extension>@<version> -o ./app/extension
 
 ```
       --api-path string                API Path to use for authenticating to Keyfactor Command. (default is KeyfactorAPI) (default "KeyfactorAPI")
+      --audience string                OAuth2 audience to request when authenticating to Keyfactor Command. Not used by all IdPs (e.g. leave unset for Entra ID).
       --auth-provider-profile string   The profile to use defined in the securely stored config. If not specified the config named 'default' will be used if it exists. (default "default")
       --auth-provider-type string      Provider type choices: (azid)
       --client-id string               OAuth2 client-id to use for authenticating to Keyfactor Command.
@@ -51,6 +52,7 @@ ext -t <token> -e <extension>@<version>,<extension>@<version> -o ./app/extension
       --offline                        Will not attempt to connect to GitHub for latest release information and resources.
       --password string                Password to use for authenticating to Keyfactor Command. WARNING: Remember to delete your console history if providing kfcPassword here in plain text.
       --profile string                 Use a specific profile from your config file. If not specified the config named 'default' will be used if it exists.
+      --scopes string                  Comma-separated list of OAuth2 scopes to request when authenticating via a third-party IdP (e.g. Entra ID: api://<app-id-uri>/.default).
       --skip-tls-verify                Disable TLS verification for API requests to Keyfactor Command.
       --token-url string               OAuth2 token endpoint full URL to use for authenticating to Keyfactor Command.
       --username string                Username to use for authenticating to Keyfactor Command.

--- a/docs/kfutil_orchs_get.md
+++ b/docs/kfutil_orchs_get.md
@@ -21,6 +21,7 @@ kfutil orchs get [flags]
 
 ```
       --api-path string                API Path to use for authenticating to Keyfactor Command. (default is KeyfactorAPI) (default "KeyfactorAPI")
+      --audience string                OAuth2 audience to request when authenticating to Keyfactor Command. Not used by all IdPs (e.g. leave unset for Entra ID).
       --auth-provider-profile string   The profile to use defined in the securely stored config. If not specified the config named 'default' will be used if it exists. (default "default")
       --auth-provider-type string      Provider type choices: (azid)
       --client-id string               OAuth2 client-id to use for authenticating to Keyfactor Command.
@@ -35,6 +36,7 @@ kfutil orchs get [flags]
       --offline                        Will not attempt to connect to GitHub for latest release information and resources.
       --password string                Password to use for authenticating to Keyfactor Command. WARNING: Remember to delete your console history if providing kfcPassword here in plain text.
       --profile string                 Use a specific profile from your config file. If not specified the config named 'default' will be used if it exists.
+      --scopes string                  Comma-separated list of OAuth2 scopes to request when authenticating via a third-party IdP (e.g. Entra ID: api://<app-id-uri>/.default).
       --skip-tls-verify                Disable TLS verification for API requests to Keyfactor Command.
       --token-url string               OAuth2 token endpoint full URL to use for authenticating to Keyfactor Command.
       --username string                Username to use for authenticating to Keyfactor Command.

--- a/docs/kfutil_orchs_list.md
+++ b/docs/kfutil_orchs_list.md
@@ -20,6 +20,7 @@ kfutil orchs list [flags]
 
 ```
       --api-path string                API Path to use for authenticating to Keyfactor Command. (default is KeyfactorAPI) (default "KeyfactorAPI")
+      --audience string                OAuth2 audience to request when authenticating to Keyfactor Command. Not used by all IdPs (e.g. leave unset for Entra ID).
       --auth-provider-profile string   The profile to use defined in the securely stored config. If not specified the config named 'default' will be used if it exists. (default "default")
       --auth-provider-type string      Provider type choices: (azid)
       --client-id string               OAuth2 client-id to use for authenticating to Keyfactor Command.
@@ -34,6 +35,7 @@ kfutil orchs list [flags]
       --offline                        Will not attempt to connect to GitHub for latest release information and resources.
       --password string                Password to use for authenticating to Keyfactor Command. WARNING: Remember to delete your console history if providing kfcPassword here in plain text.
       --profile string                 Use a specific profile from your config file. If not specified the config named 'default' will be used if it exists.
+      --scopes string                  Comma-separated list of OAuth2 scopes to request when authenticating via a third-party IdP (e.g. Entra ID: api://<app-id-uri>/.default).
       --skip-tls-verify                Disable TLS verification for API requests to Keyfactor Command.
       --token-url string               OAuth2 token endpoint full URL to use for authenticating to Keyfactor Command.
       --username string                Username to use for authenticating to Keyfactor Command.

--- a/docs/kfutil_orchs_logs.md
+++ b/docs/kfutil_orchs_logs.md
@@ -21,6 +21,7 @@ kfutil orchs logs [flags]
 
 ```
       --api-path string                API Path to use for authenticating to Keyfactor Command. (default is KeyfactorAPI) (default "KeyfactorAPI")
+      --audience string                OAuth2 audience to request when authenticating to Keyfactor Command. Not used by all IdPs (e.g. leave unset for Entra ID).
       --auth-provider-profile string   The profile to use defined in the securely stored config. If not specified the config named 'default' will be used if it exists. (default "default")
       --auth-provider-type string      Provider type choices: (azid)
       --client-id string               OAuth2 client-id to use for authenticating to Keyfactor Command.
@@ -35,6 +36,7 @@ kfutil orchs logs [flags]
       --offline                        Will not attempt to connect to GitHub for latest release information and resources.
       --password string                Password to use for authenticating to Keyfactor Command. WARNING: Remember to delete your console history if providing kfcPassword here in plain text.
       --profile string                 Use a specific profile from your config file. If not specified the config named 'default' will be used if it exists.
+      --scopes string                  Comma-separated list of OAuth2 scopes to request when authenticating via a third-party IdP (e.g. Entra ID: api://<app-id-uri>/.default).
       --skip-tls-verify                Disable TLS verification for API requests to Keyfactor Command.
       --token-url string               OAuth2 token endpoint full URL to use for authenticating to Keyfactor Command.
       --username string                Username to use for authenticating to Keyfactor Command.

--- a/docs/kfutil_orchs_reset.md
+++ b/docs/kfutil_orchs_reset.md
@@ -21,6 +21,7 @@ kfutil orchs reset [flags]
 
 ```
       --api-path string                API Path to use for authenticating to Keyfactor Command. (default is KeyfactorAPI) (default "KeyfactorAPI")
+      --audience string                OAuth2 audience to request when authenticating to Keyfactor Command. Not used by all IdPs (e.g. leave unset for Entra ID).
       --auth-provider-profile string   The profile to use defined in the securely stored config. If not specified the config named 'default' will be used if it exists. (default "default")
       --auth-provider-type string      Provider type choices: (azid)
       --client-id string               OAuth2 client-id to use for authenticating to Keyfactor Command.
@@ -35,6 +36,7 @@ kfutil orchs reset [flags]
       --offline                        Will not attempt to connect to GitHub for latest release information and resources.
       --password string                Password to use for authenticating to Keyfactor Command. WARNING: Remember to delete your console history if providing kfcPassword here in plain text.
       --profile string                 Use a specific profile from your config file. If not specified the config named 'default' will be used if it exists.
+      --scopes string                  Comma-separated list of OAuth2 scopes to request when authenticating via a third-party IdP (e.g. Entra ID: api://<app-id-uri>/.default).
       --skip-tls-verify                Disable TLS verification for API requests to Keyfactor Command.
       --token-url string               OAuth2 token endpoint full URL to use for authenticating to Keyfactor Command.
       --username string                Username to use for authenticating to Keyfactor Command.

--- a/docs/kfutil_pam-types.md
+++ b/docs/kfutil_pam-types.md
@@ -16,6 +16,7 @@ A collections of APIs and utilities for interacting with Keyfactor PAM types.
 
 ```
       --api-path string                API Path to use for authenticating to Keyfactor Command. (default is KeyfactorAPI) (default "KeyfactorAPI")
+      --audience string                OAuth2 audience to request when authenticating to Keyfactor Command. Not used by all IdPs (e.g. leave unset for Entra ID).
       --auth-provider-profile string   The profile to use defined in the securely stored config. If not specified the config named 'default' will be used if it exists. (default "default")
       --auth-provider-type string      Provider type choices: (azid)
       --client-id string               OAuth2 client-id to use for authenticating to Keyfactor Command.
@@ -30,6 +31,7 @@ A collections of APIs and utilities for interacting with Keyfactor PAM types.
       --offline                        Will not attempt to connect to GitHub for latest release information and resources.
       --password string                Password to use for authenticating to Keyfactor Command. WARNING: Remember to delete your console history if providing kfcPassword here in plain text.
       --profile string                 Use a specific profile from your config file. If not specified the config named 'default' will be used if it exists.
+      --scopes string                  Comma-separated list of OAuth2 scopes to request when authenticating via a third-party IdP (e.g. Entra ID: api://<app-id-uri>/.default).
       --skip-tls-verify                Disable TLS verification for API requests to Keyfactor Command.
       --token-url string               OAuth2 token endpoint full URL to use for authenticating to Keyfactor Command.
       --username string                Username to use for authenticating to Keyfactor Command.

--- a/docs/kfutil_pam-types_create.md
+++ b/docs/kfutil_pam-types_create.md
@@ -29,6 +29,7 @@ kfutil pam-types create [flags]
 
 ```
       --api-path string                API Path to use for authenticating to Keyfactor Command. (default is KeyfactorAPI) (default "KeyfactorAPI")
+      --audience string                OAuth2 audience to request when authenticating to Keyfactor Command. Not used by all IdPs (e.g. leave unset for Entra ID).
       --auth-provider-profile string   The profile to use defined in the securely stored config. If not specified the config named 'default' will be used if it exists. (default "default")
       --auth-provider-type string      Provider type choices: (azid)
       --client-id string               OAuth2 client-id to use for authenticating to Keyfactor Command.
@@ -43,6 +44,7 @@ kfutil pam-types create [flags]
       --offline                        Will not attempt to connect to GitHub for latest release information and resources.
       --password string                Password to use for authenticating to Keyfactor Command. WARNING: Remember to delete your console history if providing kfcPassword here in plain text.
       --profile string                 Use a specific profile from your config file. If not specified the config named 'default' will be used if it exists.
+      --scopes string                  Comma-separated list of OAuth2 scopes to request when authenticating via a third-party IdP (e.g. Entra ID: api://<app-id-uri>/.default).
       --skip-tls-verify                Disable TLS verification for API requests to Keyfactor Command.
       --token-url string               OAuth2 token endpoint full URL to use for authenticating to Keyfactor Command.
       --username string                Username to use for authenticating to Keyfactor Command.

--- a/docs/kfutil_pam-types_delete.md
+++ b/docs/kfutil_pam-types_delete.md
@@ -23,6 +23,7 @@ kfutil pam-types delete [flags]
 
 ```
       --api-path string                API Path to use for authenticating to Keyfactor Command. (default is KeyfactorAPI) (default "KeyfactorAPI")
+      --audience string                OAuth2 audience to request when authenticating to Keyfactor Command. Not used by all IdPs (e.g. leave unset for Entra ID).
       --auth-provider-profile string   The profile to use defined in the securely stored config. If not specified the config named 'default' will be used if it exists. (default "default")
       --auth-provider-type string      Provider type choices: (azid)
       --client-id string               OAuth2 client-id to use for authenticating to Keyfactor Command.
@@ -37,6 +38,7 @@ kfutil pam-types delete [flags]
       --offline                        Will not attempt to connect to GitHub for latest release information and resources.
       --password string                Password to use for authenticating to Keyfactor Command. WARNING: Remember to delete your console history if providing kfcPassword here in plain text.
       --profile string                 Use a specific profile from your config file. If not specified the config named 'default' will be used if it exists.
+      --scopes string                  Comma-separated list of OAuth2 scopes to request when authenticating via a third-party IdP (e.g. Entra ID: api://<app-id-uri>/.default).
       --skip-tls-verify                Disable TLS verification for API requests to Keyfactor Command.
       --token-url string               OAuth2 token endpoint full URL to use for authenticating to Keyfactor Command.
       --username string                Username to use for authenticating to Keyfactor Command.

--- a/docs/kfutil_pam-types_get.md
+++ b/docs/kfutil_pam-types_get.md
@@ -22,6 +22,7 @@ kfutil pam-types get [flags]
 
 ```
       --api-path string                API Path to use for authenticating to Keyfactor Command. (default is KeyfactorAPI) (default "KeyfactorAPI")
+      --audience string                OAuth2 audience to request when authenticating to Keyfactor Command. Not used by all IdPs (e.g. leave unset for Entra ID).
       --auth-provider-profile string   The profile to use defined in the securely stored config. If not specified the config named 'default' will be used if it exists. (default "default")
       --auth-provider-type string      Provider type choices: (azid)
       --client-id string               OAuth2 client-id to use for authenticating to Keyfactor Command.
@@ -36,6 +37,7 @@ kfutil pam-types get [flags]
       --offline                        Will not attempt to connect to GitHub for latest release information and resources.
       --password string                Password to use for authenticating to Keyfactor Command. WARNING: Remember to delete your console history if providing kfcPassword here in plain text.
       --profile string                 Use a specific profile from your config file. If not specified the config named 'default' will be used if it exists.
+      --scopes string                  Comma-separated list of OAuth2 scopes to request when authenticating via a third-party IdP (e.g. Entra ID: api://<app-id-uri>/.default).
       --skip-tls-verify                Disable TLS verification for API requests to Keyfactor Command.
       --token-url string               OAuth2 token endpoint full URL to use for authenticating to Keyfactor Command.
       --username string                Username to use for authenticating to Keyfactor Command.

--- a/docs/kfutil_pam-types_list.md
+++ b/docs/kfutil_pam-types_list.md
@@ -20,6 +20,7 @@ kfutil pam-types list [flags]
 
 ```
       --api-path string                API Path to use for authenticating to Keyfactor Command. (default is KeyfactorAPI) (default "KeyfactorAPI")
+      --audience string                OAuth2 audience to request when authenticating to Keyfactor Command. Not used by all IdPs (e.g. leave unset for Entra ID).
       --auth-provider-profile string   The profile to use defined in the securely stored config. If not specified the config named 'default' will be used if it exists. (default "default")
       --auth-provider-type string      Provider type choices: (azid)
       --client-id string               OAuth2 client-id to use for authenticating to Keyfactor Command.
@@ -34,6 +35,7 @@ kfutil pam-types list [flags]
       --offline                        Will not attempt to connect to GitHub for latest release information and resources.
       --password string                Password to use for authenticating to Keyfactor Command. WARNING: Remember to delete your console history if providing kfcPassword here in plain text.
       --profile string                 Use a specific profile from your config file. If not specified the config named 'default' will be used if it exists.
+      --scopes string                  Comma-separated list of OAuth2 scopes to request when authenticating via a third-party IdP (e.g. Entra ID: api://<app-id-uri>/.default).
       --skip-tls-verify                Disable TLS verification for API requests to Keyfactor Command.
       --token-url string               OAuth2 token endpoint full URL to use for authenticating to Keyfactor Command.
       --username string                Username to use for authenticating to Keyfactor Command.

--- a/docs/kfutil_pam.md
+++ b/docs/kfutil_pam.md
@@ -18,6 +18,7 @@ programmatically create, delete, edit, and list PAM Providers.
 
 ```
       --api-path string                API Path to use for authenticating to Keyfactor Command. (default is KeyfactorAPI) (default "KeyfactorAPI")
+      --audience string                OAuth2 audience to request when authenticating to Keyfactor Command. Not used by all IdPs (e.g. leave unset for Entra ID).
       --auth-provider-profile string   The profile to use defined in the securely stored config. If not specified the config named 'default' will be used if it exists. (default "default")
       --auth-provider-type string      Provider type choices: (azid)
       --client-id string               OAuth2 client-id to use for authenticating to Keyfactor Command.
@@ -32,6 +33,7 @@ programmatically create, delete, edit, and list PAM Providers.
       --offline                        Will not attempt to connect to GitHub for latest release information and resources.
       --password string                Password to use for authenticating to Keyfactor Command. WARNING: Remember to delete your console history if providing kfcPassword here in plain text.
       --profile string                 Use a specific profile from your config file. If not specified the config named 'default' will be used if it exists.
+      --scopes string                  Comma-separated list of OAuth2 scopes to request when authenticating via a third-party IdP (e.g. Entra ID: api://<app-id-uri>/.default).
       --skip-tls-verify                Disable TLS verification for API requests to Keyfactor Command.
       --token-url string               OAuth2 token endpoint full URL to use for authenticating to Keyfactor Command.
       --username string                Username to use for authenticating to Keyfactor Command.

--- a/docs/kfutil_pam_create.md
+++ b/docs/kfutil_pam_create.md
@@ -21,6 +21,7 @@ kfutil pam create [flags]
 
 ```
       --api-path string                API Path to use for authenticating to Keyfactor Command. (default is KeyfactorAPI) (default "KeyfactorAPI")
+      --audience string                OAuth2 audience to request when authenticating to Keyfactor Command. Not used by all IdPs (e.g. leave unset for Entra ID).
       --auth-provider-profile string   The profile to use defined in the securely stored config. If not specified the config named 'default' will be used if it exists. (default "default")
       --auth-provider-type string      Provider type choices: (azid)
       --client-id string               OAuth2 client-id to use for authenticating to Keyfactor Command.
@@ -35,6 +36,7 @@ kfutil pam create [flags]
       --offline                        Will not attempt to connect to GitHub for latest release information and resources.
       --password string                Password to use for authenticating to Keyfactor Command. WARNING: Remember to delete your console history if providing kfcPassword here in plain text.
       --profile string                 Use a specific profile from your config file. If not specified the config named 'default' will be used if it exists.
+      --scopes string                  Comma-separated list of OAuth2 scopes to request when authenticating via a third-party IdP (e.g. Entra ID: api://<app-id-uri>/.default).
       --skip-tls-verify                Disable TLS verification for API requests to Keyfactor Command.
       --token-url string               OAuth2 token endpoint full URL to use for authenticating to Keyfactor Command.
       --username string                Username to use for authenticating to Keyfactor Command.

--- a/docs/kfutil_pam_delete.md
+++ b/docs/kfutil_pam_delete.md
@@ -22,6 +22,7 @@ kfutil pam delete [flags]
 
 ```
       --api-path string                API Path to use for authenticating to Keyfactor Command. (default is KeyfactorAPI) (default "KeyfactorAPI")
+      --audience string                OAuth2 audience to request when authenticating to Keyfactor Command. Not used by all IdPs (e.g. leave unset for Entra ID).
       --auth-provider-profile string   The profile to use defined in the securely stored config. If not specified the config named 'default' will be used if it exists. (default "default")
       --auth-provider-type string      Provider type choices: (azid)
       --client-id string               OAuth2 client-id to use for authenticating to Keyfactor Command.
@@ -36,6 +37,7 @@ kfutil pam delete [flags]
       --offline                        Will not attempt to connect to GitHub for latest release information and resources.
       --password string                Password to use for authenticating to Keyfactor Command. WARNING: Remember to delete your console history if providing kfcPassword here in plain text.
       --profile string                 Use a specific profile from your config file. If not specified the config named 'default' will be used if it exists.
+      --scopes string                  Comma-separated list of OAuth2 scopes to request when authenticating via a third-party IdP (e.g. Entra ID: api://<app-id-uri>/.default).
       --skip-tls-verify                Disable TLS verification for API requests to Keyfactor Command.
       --token-url string               OAuth2 token endpoint full URL to use for authenticating to Keyfactor Command.
       --username string                Username to use for authenticating to Keyfactor Command.

--- a/docs/kfutil_pam_get.md
+++ b/docs/kfutil_pam_get.md
@@ -22,6 +22,7 @@ kfutil pam get [flags]
 
 ```
       --api-path string                API Path to use for authenticating to Keyfactor Command. (default is KeyfactorAPI) (default "KeyfactorAPI")
+      --audience string                OAuth2 audience to request when authenticating to Keyfactor Command. Not used by all IdPs (e.g. leave unset for Entra ID).
       --auth-provider-profile string   The profile to use defined in the securely stored config. If not specified the config named 'default' will be used if it exists. (default "default")
       --auth-provider-type string      Provider type choices: (azid)
       --client-id string               OAuth2 client-id to use for authenticating to Keyfactor Command.
@@ -36,6 +37,7 @@ kfutil pam get [flags]
       --offline                        Will not attempt to connect to GitHub for latest release information and resources.
       --password string                Password to use for authenticating to Keyfactor Command. WARNING: Remember to delete your console history if providing kfcPassword here in plain text.
       --profile string                 Use a specific profile from your config file. If not specified the config named 'default' will be used if it exists.
+      --scopes string                  Comma-separated list of OAuth2 scopes to request when authenticating via a third-party IdP (e.g. Entra ID: api://<app-id-uri>/.default).
       --skip-tls-verify                Disable TLS verification for API requests to Keyfactor Command.
       --token-url string               OAuth2 token endpoint full URL to use for authenticating to Keyfactor Command.
       --username string                Username to use for authenticating to Keyfactor Command.

--- a/docs/kfutil_pam_list.md
+++ b/docs/kfutil_pam_list.md
@@ -20,6 +20,7 @@ kfutil pam list [flags]
 
 ```
       --api-path string                API Path to use for authenticating to Keyfactor Command. (default is KeyfactorAPI) (default "KeyfactorAPI")
+      --audience string                OAuth2 audience to request when authenticating to Keyfactor Command. Not used by all IdPs (e.g. leave unset for Entra ID).
       --auth-provider-profile string   The profile to use defined in the securely stored config. If not specified the config named 'default' will be used if it exists. (default "default")
       --auth-provider-type string      Provider type choices: (azid)
       --client-id string               OAuth2 client-id to use for authenticating to Keyfactor Command.
@@ -34,6 +35,7 @@ kfutil pam list [flags]
       --offline                        Will not attempt to connect to GitHub for latest release information and resources.
       --password string                Password to use for authenticating to Keyfactor Command. WARNING: Remember to delete your console history if providing kfcPassword here in plain text.
       --profile string                 Use a specific profile from your config file. If not specified the config named 'default' will be used if it exists.
+      --scopes string                  Comma-separated list of OAuth2 scopes to request when authenticating via a third-party IdP (e.g. Entra ID: api://<app-id-uri>/.default).
       --skip-tls-verify                Disable TLS verification for API requests to Keyfactor Command.
       --token-url string               OAuth2 token endpoint full URL to use for authenticating to Keyfactor Command.
       --username string                Username to use for authenticating to Keyfactor Command.

--- a/docs/kfutil_pam_update.md
+++ b/docs/kfutil_pam_update.md
@@ -21,6 +21,7 @@ kfutil pam update [flags]
 
 ```
       --api-path string                API Path to use for authenticating to Keyfactor Command. (default is KeyfactorAPI) (default "KeyfactorAPI")
+      --audience string                OAuth2 audience to request when authenticating to Keyfactor Command. Not used by all IdPs (e.g. leave unset for Entra ID).
       --auth-provider-profile string   The profile to use defined in the securely stored config. If not specified the config named 'default' will be used if it exists. (default "default")
       --auth-provider-type string      Provider type choices: (azid)
       --client-id string               OAuth2 client-id to use for authenticating to Keyfactor Command.
@@ -35,6 +36,7 @@ kfutil pam update [flags]
       --offline                        Will not attempt to connect to GitHub for latest release information and resources.
       --password string                Password to use for authenticating to Keyfactor Command. WARNING: Remember to delete your console history if providing kfcPassword here in plain text.
       --profile string                 Use a specific profile from your config file. If not specified the config named 'default' will be used if it exists.
+      --scopes string                  Comma-separated list of OAuth2 scopes to request when authenticating via a third-party IdP (e.g. Entra ID: api://<app-id-uri>/.default).
       --skip-tls-verify                Disable TLS verification for API requests to Keyfactor Command.
       --token-url string               OAuth2 token endpoint full URL to use for authenticating to Keyfactor Command.
       --username string                Username to use for authenticating to Keyfactor Command.

--- a/docs/kfutil_status.md
+++ b/docs/kfutil_status.md
@@ -20,6 +20,7 @@ kfutil status [flags]
 
 ```
       --api-path string                API Path to use for authenticating to Keyfactor Command. (default is KeyfactorAPI) (default "KeyfactorAPI")
+      --audience string                OAuth2 audience to request when authenticating to Keyfactor Command. Not used by all IdPs (e.g. leave unset for Entra ID).
       --auth-provider-profile string   The profile to use defined in the securely stored config. If not specified the config named 'default' will be used if it exists. (default "default")
       --auth-provider-type string      Provider type choices: (azid)
       --client-id string               OAuth2 client-id to use for authenticating to Keyfactor Command.
@@ -34,6 +35,7 @@ kfutil status [flags]
       --offline                        Will not attempt to connect to GitHub for latest release information and resources.
       --password string                Password to use for authenticating to Keyfactor Command. WARNING: Remember to delete your console history if providing kfcPassword here in plain text.
       --profile string                 Use a specific profile from your config file. If not specified the config named 'default' will be used if it exists.
+      --scopes string                  Comma-separated list of OAuth2 scopes to request when authenticating via a third-party IdP (e.g. Entra ID: api://<app-id-uri>/.default).
       --skip-tls-verify                Disable TLS verification for API requests to Keyfactor Command.
       --token-url string               OAuth2 token endpoint full URL to use for authenticating to Keyfactor Command.
       --username string                Username to use for authenticating to Keyfactor Command.

--- a/docs/kfutil_store-types.md
+++ b/docs/kfutil_store-types.md
@@ -16,6 +16,7 @@ A collections of APIs and utilities for interacting with Keyfactor certificate s
 
 ```
       --api-path string                API Path to use for authenticating to Keyfactor Command. (default is KeyfactorAPI) (default "KeyfactorAPI")
+      --audience string                OAuth2 audience to request when authenticating to Keyfactor Command. Not used by all IdPs (e.g. leave unset for Entra ID).
       --auth-provider-profile string   The profile to use defined in the securely stored config. If not specified the config named 'default' will be used if it exists. (default "default")
       --auth-provider-type string      Provider type choices: (azid)
       --client-id string               OAuth2 client-id to use for authenticating to Keyfactor Command.
@@ -30,6 +31,7 @@ A collections of APIs and utilities for interacting with Keyfactor certificate s
       --offline                        Will not attempt to connect to GitHub for latest release information and resources.
       --password string                Password to use for authenticating to Keyfactor Command. WARNING: Remember to delete your console history if providing kfcPassword here in plain text.
       --profile string                 Use a specific profile from your config file. If not specified the config named 'default' will be used if it exists.
+      --scopes string                  Comma-separated list of OAuth2 scopes to request when authenticating via a third-party IdP (e.g. Entra ID: api://<app-id-uri>/.default).
       --skip-tls-verify                Disable TLS verification for API requests to Keyfactor Command.
       --token-url string               OAuth2 token endpoint full URL to use for authenticating to Keyfactor Command.
       --username string                Username to use for authenticating to Keyfactor Command.

--- a/docs/kfutil_store-types_create.md
+++ b/docs/kfutil_store-types_create.md
@@ -26,6 +26,7 @@ kfutil store-types create [flags]
 
 ```
       --api-path string                API Path to use for authenticating to Keyfactor Command. (default is KeyfactorAPI) (default "KeyfactorAPI")
+      --audience string                OAuth2 audience to request when authenticating to Keyfactor Command. Not used by all IdPs (e.g. leave unset for Entra ID).
       --auth-provider-profile string   The profile to use defined in the securely stored config. If not specified the config named 'default' will be used if it exists. (default "default")
       --auth-provider-type string      Provider type choices: (azid)
       --client-id string               OAuth2 client-id to use for authenticating to Keyfactor Command.
@@ -40,6 +41,7 @@ kfutil store-types create [flags]
       --offline                        Will not attempt to connect to GitHub for latest release information and resources.
       --password string                Password to use for authenticating to Keyfactor Command. WARNING: Remember to delete your console history if providing kfcPassword here in plain text.
       --profile string                 Use a specific profile from your config file. If not specified the config named 'default' will be used if it exists.
+      --scopes string                  Comma-separated list of OAuth2 scopes to request when authenticating via a third-party IdP (e.g. Entra ID: api://<app-id-uri>/.default).
       --skip-tls-verify                Disable TLS verification for API requests to Keyfactor Command.
       --token-url string               OAuth2 token endpoint full URL to use for authenticating to Keyfactor Command.
       --username string                Username to use for authenticating to Keyfactor Command.

--- a/docs/kfutil_store-types_delete.md
+++ b/docs/kfutil_store-types_delete.md
@@ -24,6 +24,7 @@ kfutil store-types delete [flags]
 
 ```
       --api-path string                API Path to use for authenticating to Keyfactor Command. (default is KeyfactorAPI) (default "KeyfactorAPI")
+      --audience string                OAuth2 audience to request when authenticating to Keyfactor Command. Not used by all IdPs (e.g. leave unset for Entra ID).
       --auth-provider-profile string   The profile to use defined in the securely stored config. If not specified the config named 'default' will be used if it exists. (default "default")
       --auth-provider-type string      Provider type choices: (azid)
       --client-id string               OAuth2 client-id to use for authenticating to Keyfactor Command.
@@ -38,6 +39,7 @@ kfutil store-types delete [flags]
       --offline                        Will not attempt to connect to GitHub for latest release information and resources.
       --password string                Password to use for authenticating to Keyfactor Command. WARNING: Remember to delete your console history if providing kfcPassword here in plain text.
       --profile string                 Use a specific profile from your config file. If not specified the config named 'default' will be used if it exists.
+      --scopes string                  Comma-separated list of OAuth2 scopes to request when authenticating via a third-party IdP (e.g. Entra ID: api://<app-id-uri>/.default).
       --skip-tls-verify                Disable TLS verification for API requests to Keyfactor Command.
       --token-url string               OAuth2 token endpoint full URL to use for authenticating to Keyfactor Command.
       --username string                Username to use for authenticating to Keyfactor Command.

--- a/docs/kfutil_store-types_get.md
+++ b/docs/kfutil_store-types_get.md
@@ -25,6 +25,7 @@ kfutil store-types get [-i <store-type-id> | -n <store-type-name>] [-b <git-ref>
 
 ```
       --api-path string                API Path to use for authenticating to Keyfactor Command. (default is KeyfactorAPI) (default "KeyfactorAPI")
+      --audience string                OAuth2 audience to request when authenticating to Keyfactor Command. Not used by all IdPs (e.g. leave unset for Entra ID).
       --auth-provider-profile string   The profile to use defined in the securely stored config. If not specified the config named 'default' will be used if it exists. (default "default")
       --auth-provider-type string      Provider type choices: (azid)
       --client-id string               OAuth2 client-id to use for authenticating to Keyfactor Command.
@@ -39,6 +40,7 @@ kfutil store-types get [-i <store-type-id> | -n <store-type-name>] [-b <git-ref>
       --offline                        Will not attempt to connect to GitHub for latest release information and resources.
       --password string                Password to use for authenticating to Keyfactor Command. WARNING: Remember to delete your console history if providing kfcPassword here in plain text.
       --profile string                 Use a specific profile from your config file. If not specified the config named 'default' will be used if it exists.
+      --scopes string                  Comma-separated list of OAuth2 scopes to request when authenticating via a third-party IdP (e.g. Entra ID: api://<app-id-uri>/.default).
       --skip-tls-verify                Disable TLS verification for API requests to Keyfactor Command.
       --token-url string               OAuth2 token endpoint full URL to use for authenticating to Keyfactor Command.
       --username string                Username to use for authenticating to Keyfactor Command.

--- a/docs/kfutil_store-types_list.md
+++ b/docs/kfutil_store-types_list.md
@@ -20,6 +20,7 @@ kfutil store-types list [flags]
 
 ```
       --api-path string                API Path to use for authenticating to Keyfactor Command. (default is KeyfactorAPI) (default "KeyfactorAPI")
+      --audience string                OAuth2 audience to request when authenticating to Keyfactor Command. Not used by all IdPs (e.g. leave unset for Entra ID).
       --auth-provider-profile string   The profile to use defined in the securely stored config. If not specified the config named 'default' will be used if it exists. (default "default")
       --auth-provider-type string      Provider type choices: (azid)
       --client-id string               OAuth2 client-id to use for authenticating to Keyfactor Command.
@@ -34,6 +35,7 @@ kfutil store-types list [flags]
       --offline                        Will not attempt to connect to GitHub for latest release information and resources.
       --password string                Password to use for authenticating to Keyfactor Command. WARNING: Remember to delete your console history if providing kfcPassword here in plain text.
       --profile string                 Use a specific profile from your config file. If not specified the config named 'default' will be used if it exists.
+      --scopes string                  Comma-separated list of OAuth2 scopes to request when authenticating via a third-party IdP (e.g. Entra ID: api://<app-id-uri>/.default).
       --skip-tls-verify                Disable TLS verification for API requests to Keyfactor Command.
       --token-url string               OAuth2 token endpoint full URL to use for authenticating to Keyfactor Command.
       --username string                Username to use for authenticating to Keyfactor Command.

--- a/docs/kfutil_store-types_templates-fetch.md
+++ b/docs/kfutil_store-types_templates-fetch.md
@@ -22,6 +22,7 @@ kfutil store-types templates-fetch [flags]
 
 ```
       --api-path string                API Path to use for authenticating to Keyfactor Command. (default is KeyfactorAPI) (default "KeyfactorAPI")
+      --audience string                OAuth2 audience to request when authenticating to Keyfactor Command. Not used by all IdPs (e.g. leave unset for Entra ID).
       --auth-provider-profile string   The profile to use defined in the securely stored config. If not specified the config named 'default' will be used if it exists. (default "default")
       --auth-provider-type string      Provider type choices: (azid)
       --client-id string               OAuth2 client-id to use for authenticating to Keyfactor Command.
@@ -36,6 +37,7 @@ kfutil store-types templates-fetch [flags]
       --offline                        Will not attempt to connect to GitHub for latest release information and resources.
       --password string                Password to use for authenticating to Keyfactor Command. WARNING: Remember to delete your console history if providing kfcPassword here in plain text.
       --profile string                 Use a specific profile from your config file. If not specified the config named 'default' will be used if it exists.
+      --scopes string                  Comma-separated list of OAuth2 scopes to request when authenticating via a third-party IdP (e.g. Entra ID: api://<app-id-uri>/.default).
       --skip-tls-verify                Disable TLS verification for API requests to Keyfactor Command.
       --token-url string               OAuth2 token endpoint full URL to use for authenticating to Keyfactor Command.
       --username string                Username to use for authenticating to Keyfactor Command.

--- a/docs/kfutil_stores.md
+++ b/docs/kfutil_stores.md
@@ -16,6 +16,7 @@ A collections of APIs and utilities for interacting with Keyfactor certificate s
 
 ```
       --api-path string                API Path to use for authenticating to Keyfactor Command. (default is KeyfactorAPI) (default "KeyfactorAPI")
+      --audience string                OAuth2 audience to request when authenticating to Keyfactor Command. Not used by all IdPs (e.g. leave unset for Entra ID).
       --auth-provider-profile string   The profile to use defined in the securely stored config. If not specified the config named 'default' will be used if it exists. (default "default")
       --auth-provider-type string      Provider type choices: (azid)
       --client-id string               OAuth2 client-id to use for authenticating to Keyfactor Command.
@@ -30,6 +31,7 @@ A collections of APIs and utilities for interacting with Keyfactor certificate s
       --offline                        Will not attempt to connect to GitHub for latest release information and resources.
       --password string                Password to use for authenticating to Keyfactor Command. WARNING: Remember to delete your console history if providing kfcPassword here in plain text.
       --profile string                 Use a specific profile from your config file. If not specified the config named 'default' will be used if it exists.
+      --scopes string                  Comma-separated list of OAuth2 scopes to request when authenticating via a third-party IdP (e.g. Entra ID: api://<app-id-uri>/.default).
       --skip-tls-verify                Disable TLS verification for API requests to Keyfactor Command.
       --token-url string               OAuth2 token endpoint full URL to use for authenticating to Keyfactor Command.
       --username string                Username to use for authenticating to Keyfactor Command.

--- a/docs/kfutil_stores_delete.md
+++ b/docs/kfutil_stores_delete.md
@@ -23,6 +23,7 @@ kfutil stores delete [flags]
 
 ```
       --api-path string                API Path to use for authenticating to Keyfactor Command. (default is KeyfactorAPI) (default "KeyfactorAPI")
+      --audience string                OAuth2 audience to request when authenticating to Keyfactor Command. Not used by all IdPs (e.g. leave unset for Entra ID).
       --auth-provider-profile string   The profile to use defined in the securely stored config. If not specified the config named 'default' will be used if it exists. (default "default")
       --auth-provider-type string      Provider type choices: (azid)
       --client-id string               OAuth2 client-id to use for authenticating to Keyfactor Command.
@@ -37,6 +38,7 @@ kfutil stores delete [flags]
       --offline                        Will not attempt to connect to GitHub for latest release information and resources.
       --password string                Password to use for authenticating to Keyfactor Command. WARNING: Remember to delete your console history if providing kfcPassword here in plain text.
       --profile string                 Use a specific profile from your config file. If not specified the config named 'default' will be used if it exists.
+      --scopes string                  Comma-separated list of OAuth2 scopes to request when authenticating via a third-party IdP (e.g. Entra ID: api://<app-id-uri>/.default).
       --skip-tls-verify                Disable TLS verification for API requests to Keyfactor Command.
       --token-url string               OAuth2 token endpoint full URL to use for authenticating to Keyfactor Command.
       --username string                Username to use for authenticating to Keyfactor Command.

--- a/docs/kfutil_stores_export.md
+++ b/docs/kfutil_stores_export.md
@@ -24,6 +24,7 @@ kfutil stores export [flags]
 
 ```
       --api-path string                API Path to use for authenticating to Keyfactor Command. (default is KeyfactorAPI) (default "KeyfactorAPI")
+      --audience string                OAuth2 audience to request when authenticating to Keyfactor Command. Not used by all IdPs (e.g. leave unset for Entra ID).
       --auth-provider-profile string   The profile to use defined in the securely stored config. If not specified the config named 'default' will be used if it exists. (default "default")
       --auth-provider-type string      Provider type choices: (azid)
       --client-id string               OAuth2 client-id to use for authenticating to Keyfactor Command.
@@ -38,6 +39,7 @@ kfutil stores export [flags]
       --offline                        Will not attempt to connect to GitHub for latest release information and resources.
       --password string                Password to use for authenticating to Keyfactor Command. WARNING: Remember to delete your console history if providing kfcPassword here in plain text.
       --profile string                 Use a specific profile from your config file. If not specified the config named 'default' will be used if it exists.
+      --scopes string                  Comma-separated list of OAuth2 scopes to request when authenticating via a third-party IdP (e.g. Entra ID: api://<app-id-uri>/.default).
       --skip-tls-verify                Disable TLS verification for API requests to Keyfactor Command.
       --token-url string               OAuth2 token endpoint full URL to use for authenticating to Keyfactor Command.
       --username string                Username to use for authenticating to Keyfactor Command.

--- a/docs/kfutil_stores_get.md
+++ b/docs/kfutil_stores_get.md
@@ -21,6 +21,7 @@ kfutil stores get [flags]
 
 ```
       --api-path string                API Path to use for authenticating to Keyfactor Command. (default is KeyfactorAPI) (default "KeyfactorAPI")
+      --audience string                OAuth2 audience to request when authenticating to Keyfactor Command. Not used by all IdPs (e.g. leave unset for Entra ID).
       --auth-provider-profile string   The profile to use defined in the securely stored config. If not specified the config named 'default' will be used if it exists. (default "default")
       --auth-provider-type string      Provider type choices: (azid)
       --client-id string               OAuth2 client-id to use for authenticating to Keyfactor Command.
@@ -35,6 +36,7 @@ kfutil stores get [flags]
       --offline                        Will not attempt to connect to GitHub for latest release information and resources.
       --password string                Password to use for authenticating to Keyfactor Command. WARNING: Remember to delete your console history if providing kfcPassword here in plain text.
       --profile string                 Use a specific profile from your config file. If not specified the config named 'default' will be used if it exists.
+      --scopes string                  Comma-separated list of OAuth2 scopes to request when authenticating via a third-party IdP (e.g. Entra ID: api://<app-id-uri>/.default).
       --skip-tls-verify                Disable TLS verification for API requests to Keyfactor Command.
       --token-url string               OAuth2 token endpoint full URL to use for authenticating to Keyfactor Command.
       --username string                Username to use for authenticating to Keyfactor Command.

--- a/docs/kfutil_stores_import.md
+++ b/docs/kfutil_stores_import.md
@@ -16,6 +16,7 @@ Tools for generating import templates and importing certificate stores
 
 ```
       --api-path string                API Path to use for authenticating to Keyfactor Command. (default is KeyfactorAPI) (default "KeyfactorAPI")
+      --audience string                OAuth2 audience to request when authenticating to Keyfactor Command. Not used by all IdPs (e.g. leave unset for Entra ID).
       --auth-provider-profile string   The profile to use defined in the securely stored config. If not specified the config named 'default' will be used if it exists. (default "default")
       --auth-provider-type string      Provider type choices: (azid)
       --client-id string               OAuth2 client-id to use for authenticating to Keyfactor Command.
@@ -30,6 +31,7 @@ Tools for generating import templates and importing certificate stores
       --offline                        Will not attempt to connect to GitHub for latest release information and resources.
       --password string                Password to use for authenticating to Keyfactor Command. WARNING: Remember to delete your console history if providing kfcPassword here in plain text.
       --profile string                 Use a specific profile from your config file. If not specified the config named 'default' will be used if it exists.
+      --scopes string                  Comma-separated list of OAuth2 scopes to request when authenticating via a third-party IdP (e.g. Entra ID: api://<app-id-uri>/.default).
       --skip-tls-verify                Disable TLS verification for API requests to Keyfactor Command.
       --token-url string               OAuth2 token endpoint full URL to use for authenticating to Keyfactor Command.
       --username string                Username to use for authenticating to Keyfactor Command.

--- a/docs/kfutil_stores_import_csv.md
+++ b/docs/kfutil_stores_import_csv.md
@@ -69,6 +69,7 @@ kfutil stores import csv --file <file name to import> --store-type-id <store typ
 
 ```
       --api-path string                API Path to use for authenticating to Keyfactor Command. (default is KeyfactorAPI) (default "KeyfactorAPI")
+      --audience string                OAuth2 audience to request when authenticating to Keyfactor Command. Not used by all IdPs (e.g. leave unset for Entra ID).
       --auth-provider-profile string   The profile to use defined in the securely stored config. If not specified the config named 'default' will be used if it exists. (default "default")
       --auth-provider-type string      Provider type choices: (azid)
       --client-id string               OAuth2 client-id to use for authenticating to Keyfactor Command.
@@ -83,6 +84,7 @@ kfutil stores import csv --file <file name to import> --store-type-id <store typ
       --offline                        Will not attempt to connect to GitHub for latest release information and resources.
       --password string                Password to use for authenticating to Keyfactor Command. WARNING: Remember to delete your console history if providing kfcPassword here in plain text.
       --profile string                 Use a specific profile from your config file. If not specified the config named 'default' will be used if it exists.
+      --scopes string                  Comma-separated list of OAuth2 scopes to request when authenticating via a third-party IdP (e.g. Entra ID: api://<app-id-uri>/.default).
       --skip-tls-verify                Disable TLS verification for API requests to Keyfactor Command.
       --token-url string               OAuth2 token endpoint full URL to use for authenticating to Keyfactor Command.
       --username string                Username to use for authenticating to Keyfactor Command.

--- a/docs/kfutil_stores_import_generate-template.md
+++ b/docs/kfutil_stores_import_generate-template.md
@@ -26,6 +26,7 @@ kfutil stores import generate-template --store-type-id <store type id> --store-t
 
 ```
       --api-path string                API Path to use for authenticating to Keyfactor Command. (default is KeyfactorAPI) (default "KeyfactorAPI")
+      --audience string                OAuth2 audience to request when authenticating to Keyfactor Command. Not used by all IdPs (e.g. leave unset for Entra ID).
       --auth-provider-profile string   The profile to use defined in the securely stored config. If not specified the config named 'default' will be used if it exists. (default "default")
       --auth-provider-type string      Provider type choices: (azid)
       --client-id string               OAuth2 client-id to use for authenticating to Keyfactor Command.
@@ -40,6 +41,7 @@ kfutil stores import generate-template --store-type-id <store type id> --store-t
       --offline                        Will not attempt to connect to GitHub for latest release information and resources.
       --password string                Password to use for authenticating to Keyfactor Command. WARNING: Remember to delete your console history if providing kfcPassword here in plain text.
       --profile string                 Use a specific profile from your config file. If not specified the config named 'default' will be used if it exists.
+      --scopes string                  Comma-separated list of OAuth2 scopes to request when authenticating via a third-party IdP (e.g. Entra ID: api://<app-id-uri>/.default).
       --skip-tls-verify                Disable TLS verification for API requests to Keyfactor Command.
       --token-url string               OAuth2 token endpoint full URL to use for authenticating to Keyfactor Command.
       --username string                Username to use for authenticating to Keyfactor Command.

--- a/docs/kfutil_stores_inventory.md
+++ b/docs/kfutil_stores_inventory.md
@@ -16,6 +16,7 @@ Commands related to certificate store inventory management
 
 ```
       --api-path string                API Path to use for authenticating to Keyfactor Command. (default is KeyfactorAPI) (default "KeyfactorAPI")
+      --audience string                OAuth2 audience to request when authenticating to Keyfactor Command. Not used by all IdPs (e.g. leave unset for Entra ID).
       --auth-provider-profile string   The profile to use defined in the securely stored config. If not specified the config named 'default' will be used if it exists. (default "default")
       --auth-provider-type string      Provider type choices: (azid)
       --client-id string               OAuth2 client-id to use for authenticating to Keyfactor Command.
@@ -30,6 +31,7 @@ Commands related to certificate store inventory management
       --offline                        Will not attempt to connect to GitHub for latest release information and resources.
       --password string                Password to use for authenticating to Keyfactor Command. WARNING: Remember to delete your console history if providing kfcPassword here in plain text.
       --profile string                 Use a specific profile from your config file. If not specified the config named 'default' will be used if it exists.
+      --scopes string                  Comma-separated list of OAuth2 scopes to request when authenticating via a third-party IdP (e.g. Entra ID: api://<app-id-uri>/.default).
       --skip-tls-verify                Disable TLS verification for API requests to Keyfactor Command.
       --token-url string               OAuth2 token endpoint full URL to use for authenticating to Keyfactor Command.
       --username string                Username to use for authenticating to Keyfactor Command.

--- a/docs/kfutil_stores_inventory_add.md
+++ b/docs/kfutil_stores_inventory_add.md
@@ -34,6 +34,7 @@ kfutil stores inventory add [flags]
 
 ```
       --api-path string                API Path to use for authenticating to Keyfactor Command. (default is KeyfactorAPI) (default "KeyfactorAPI")
+      --audience string                OAuth2 audience to request when authenticating to Keyfactor Command. Not used by all IdPs (e.g. leave unset for Entra ID).
       --auth-provider-profile string   The profile to use defined in the securely stored config. If not specified the config named 'default' will be used if it exists. (default "default")
       --auth-provider-type string      Provider type choices: (azid)
       --client-id string               OAuth2 client-id to use for authenticating to Keyfactor Command.
@@ -48,6 +49,7 @@ kfutil stores inventory add [flags]
       --offline                        Will not attempt to connect to GitHub for latest release information and resources.
       --password string                Password to use for authenticating to Keyfactor Command. WARNING: Remember to delete your console history if providing kfcPassword here in plain text.
       --profile string                 Use a specific profile from your config file. If not specified the config named 'default' will be used if it exists.
+      --scopes string                  Comma-separated list of OAuth2 scopes to request when authenticating via a third-party IdP (e.g. Entra ID: api://<app-id-uri>/.default).
       --skip-tls-verify                Disable TLS verification for API requests to Keyfactor Command.
       --token-url string               OAuth2 token endpoint full URL to use for authenticating to Keyfactor Command.
       --username string                Username to use for authenticating to Keyfactor Command.

--- a/docs/kfutil_stores_inventory_remove.md
+++ b/docs/kfutil_stores_inventory_remove.md
@@ -30,6 +30,7 @@ kfutil stores inventory remove [flags]
 
 ```
       --api-path string                API Path to use for authenticating to Keyfactor Command. (default is KeyfactorAPI) (default "KeyfactorAPI")
+      --audience string                OAuth2 audience to request when authenticating to Keyfactor Command. Not used by all IdPs (e.g. leave unset for Entra ID).
       --auth-provider-profile string   The profile to use defined in the securely stored config. If not specified the config named 'default' will be used if it exists. (default "default")
       --auth-provider-type string      Provider type choices: (azid)
       --client-id string               OAuth2 client-id to use for authenticating to Keyfactor Command.
@@ -44,6 +45,7 @@ kfutil stores inventory remove [flags]
       --offline                        Will not attempt to connect to GitHub for latest release information and resources.
       --password string                Password to use for authenticating to Keyfactor Command. WARNING: Remember to delete your console history if providing kfcPassword here in plain text.
       --profile string                 Use a specific profile from your config file. If not specified the config named 'default' will be used if it exists.
+      --scopes string                  Comma-separated list of OAuth2 scopes to request when authenticating via a third-party IdP (e.g. Entra ID: api://<app-id-uri>/.default).
       --skip-tls-verify                Disable TLS verification for API requests to Keyfactor Command.
       --token-url string               OAuth2 token endpoint full URL to use for authenticating to Keyfactor Command.
       --username string                Username to use for authenticating to Keyfactor Command.

--- a/docs/kfutil_stores_inventory_show.md
+++ b/docs/kfutil_stores_inventory_show.md
@@ -24,6 +24,7 @@ kfutil stores inventory show [flags]
 
 ```
       --api-path string                API Path to use for authenticating to Keyfactor Command. (default is KeyfactorAPI) (default "KeyfactorAPI")
+      --audience string                OAuth2 audience to request when authenticating to Keyfactor Command. Not used by all IdPs (e.g. leave unset for Entra ID).
       --auth-provider-profile string   The profile to use defined in the securely stored config. If not specified the config named 'default' will be used if it exists. (default "default")
       --auth-provider-type string      Provider type choices: (azid)
       --client-id string               OAuth2 client-id to use for authenticating to Keyfactor Command.
@@ -38,6 +39,7 @@ kfutil stores inventory show [flags]
       --offline                        Will not attempt to connect to GitHub for latest release information and resources.
       --password string                Password to use for authenticating to Keyfactor Command. WARNING: Remember to delete your console history if providing kfcPassword here in plain text.
       --profile string                 Use a specific profile from your config file. If not specified the config named 'default' will be used if it exists.
+      --scopes string                  Comma-separated list of OAuth2 scopes to request when authenticating via a third-party IdP (e.g. Entra ID: api://<app-id-uri>/.default).
       --skip-tls-verify                Disable TLS verification for API requests to Keyfactor Command.
       --token-url string               OAuth2 token endpoint full URL to use for authenticating to Keyfactor Command.
       --username string                Username to use for authenticating to Keyfactor Command.

--- a/docs/kfutil_stores_list.md
+++ b/docs/kfutil_stores_list.md
@@ -20,6 +20,7 @@ kfutil stores list [flags]
 
 ```
       --api-path string                API Path to use for authenticating to Keyfactor Command. (default is KeyfactorAPI) (default "KeyfactorAPI")
+      --audience string                OAuth2 audience to request when authenticating to Keyfactor Command. Not used by all IdPs (e.g. leave unset for Entra ID).
       --auth-provider-profile string   The profile to use defined in the securely stored config. If not specified the config named 'default' will be used if it exists. (default "default")
       --auth-provider-type string      Provider type choices: (azid)
       --client-id string               OAuth2 client-id to use for authenticating to Keyfactor Command.
@@ -34,6 +35,7 @@ kfutil stores list [flags]
       --offline                        Will not attempt to connect to GitHub for latest release information and resources.
       --password string                Password to use for authenticating to Keyfactor Command. WARNING: Remember to delete your console history if providing kfcPassword here in plain text.
       --profile string                 Use a specific profile from your config file. If not specified the config named 'default' will be used if it exists.
+      --scopes string                  Comma-separated list of OAuth2 scopes to request when authenticating via a third-party IdP (e.g. Entra ID: api://<app-id-uri>/.default).
       --skip-tls-verify                Disable TLS verification for API requests to Keyfactor Command.
       --token-url string               OAuth2 token endpoint full URL to use for authenticating to Keyfactor Command.
       --username string                Username to use for authenticating to Keyfactor Command.

--- a/docs/kfutil_stores_rot.md
+++ b/docs/kfutil_stores_rot.md
@@ -28,6 +28,7 @@ kfutil stores rot reconcile --import-csv <audit-file>
 
 ```
       --api-path string                API Path to use for authenticating to Keyfactor Command. (default is KeyfactorAPI) (default "KeyfactorAPI")
+      --audience string                OAuth2 audience to request when authenticating to Keyfactor Command. Not used by all IdPs (e.g. leave unset for Entra ID).
       --auth-provider-profile string   The profile to use defined in the securely stored config. If not specified the config named 'default' will be used if it exists. (default "default")
       --auth-provider-type string      Provider type choices: (azid)
       --client-id string               OAuth2 client-id to use for authenticating to Keyfactor Command.
@@ -42,6 +43,7 @@ kfutil stores rot reconcile --import-csv <audit-file>
       --offline                        Will not attempt to connect to GitHub for latest release information and resources.
       --password string                Password to use for authenticating to Keyfactor Command. WARNING: Remember to delete your console history if providing kfcPassword here in plain text.
       --profile string                 Use a specific profile from your config file. If not specified the config named 'default' will be used if it exists.
+      --scopes string                  Comma-separated list of OAuth2 scopes to request when authenticating via a third-party IdP (e.g. Entra ID: api://<app-id-uri>/.default).
       --skip-tls-verify                Disable TLS verification for API requests to Keyfactor Command.
       --token-url string               OAuth2 token endpoint full URL to use for authenticating to Keyfactor Command.
       --username string                Username to use for authenticating to Keyfactor Command.

--- a/docs/kfutil_stores_rot_audit.md
+++ b/docs/kfutil_stores_rot_audit.md
@@ -28,6 +28,7 @@ kfutil stores rot audit [flags]
 
 ```
       --api-path string                API Path to use for authenticating to Keyfactor Command. (default is KeyfactorAPI) (default "KeyfactorAPI")
+      --audience string                OAuth2 audience to request when authenticating to Keyfactor Command. Not used by all IdPs (e.g. leave unset for Entra ID).
       --auth-provider-profile string   The profile to use defined in the securely stored config. If not specified the config named 'default' will be used if it exists. (default "default")
       --auth-provider-type string      Provider type choices: (azid)
       --client-id string               OAuth2 client-id to use for authenticating to Keyfactor Command.
@@ -42,6 +43,7 @@ kfutil stores rot audit [flags]
       --offline                        Will not attempt to connect to GitHub for latest release information and resources.
       --password string                Password to use for authenticating to Keyfactor Command. WARNING: Remember to delete your console history if providing kfcPassword here in plain text.
       --profile string                 Use a specific profile from your config file. If not specified the config named 'default' will be used if it exists.
+      --scopes string                  Comma-separated list of OAuth2 scopes to request when authenticating via a third-party IdP (e.g. Entra ID: api://<app-id-uri>/.default).
       --skip-tls-verify                Disable TLS verification for API requests to Keyfactor Command.
       --token-url string               OAuth2 token endpoint full URL to use for authenticating to Keyfactor Command.
       --username string                Username to use for authenticating to Keyfactor Command.

--- a/docs/kfutil_stores_rot_generate-template.md
+++ b/docs/kfutil_stores_rot_generate-template.md
@@ -27,6 +27,7 @@ kfutil stores rot generate-template [flags]
 
 ```
       --api-path string                API Path to use for authenticating to Keyfactor Command. (default is KeyfactorAPI) (default "KeyfactorAPI")
+      --audience string                OAuth2 audience to request when authenticating to Keyfactor Command. Not used by all IdPs (e.g. leave unset for Entra ID).
       --auth-provider-profile string   The profile to use defined in the securely stored config. If not specified the config named 'default' will be used if it exists. (default "default")
       --auth-provider-type string      Provider type choices: (azid)
       --client-id string               OAuth2 client-id to use for authenticating to Keyfactor Command.
@@ -40,6 +41,7 @@ kfutil stores rot generate-template [flags]
       --offline                        Will not attempt to connect to GitHub for latest release information and resources.
       --password string                Password to use for authenticating to Keyfactor Command. WARNING: Remember to delete your console history if providing kfcPassword here in plain text.
       --profile string                 Use a specific profile from your config file. If not specified the config named 'default' will be used if it exists.
+      --scopes string                  Comma-separated list of OAuth2 scopes to request when authenticating via a third-party IdP (e.g. Entra ID: api://<app-id-uri>/.default).
       --skip-tls-verify                Disable TLS verification for API requests to Keyfactor Command.
       --token-url string               OAuth2 token endpoint full URL to use for authenticating to Keyfactor Command.
       --username string                Username to use for authenticating to Keyfactor Command.

--- a/docs/kfutil_stores_rot_reconcile.md
+++ b/docs/kfutil_stores_rot_reconcile.md
@@ -33,6 +33,7 @@ kfutil stores rot reconcile [flags]
 
 ```
       --api-path string                API Path to use for authenticating to Keyfactor Command. (default is KeyfactorAPI) (default "KeyfactorAPI")
+      --audience string                OAuth2 audience to request when authenticating to Keyfactor Command. Not used by all IdPs (e.g. leave unset for Entra ID).
       --auth-provider-profile string   The profile to use defined in the securely stored config. If not specified the config named 'default' will be used if it exists. (default "default")
       --auth-provider-type string      Provider type choices: (azid)
       --client-id string               OAuth2 client-id to use for authenticating to Keyfactor Command.
@@ -47,6 +48,7 @@ kfutil stores rot reconcile [flags]
       --offline                        Will not attempt to connect to GitHub for latest release information and resources.
       --password string                Password to use for authenticating to Keyfactor Command. WARNING: Remember to delete your console history if providing kfcPassword here in plain text.
       --profile string                 Use a specific profile from your config file. If not specified the config named 'default' will be used if it exists.
+      --scopes string                  Comma-separated list of OAuth2 scopes to request when authenticating via a third-party IdP (e.g. Entra ID: api://<app-id-uri>/.default).
       --skip-tls-verify                Disable TLS verification for API requests to Keyfactor Command.
       --token-url string               OAuth2 token endpoint full URL to use for authenticating to Keyfactor Command.
       --username string                Username to use for authenticating to Keyfactor Command.

--- a/docs/kfutil_upgrade.md
+++ b/docs/kfutil_upgrade.md
@@ -33,6 +33,7 @@ kfutil upgrade [flags]
 
 ```
       --api-path string                API Path to use for authenticating to Keyfactor Command. (default is KeyfactorAPI) (default "KeyfactorAPI")
+      --audience string                OAuth2 audience to request when authenticating to Keyfactor Command. Not used by all IdPs (e.g. leave unset for Entra ID).
       --auth-provider-profile string   The profile to use defined in the securely stored config. If not specified the config named 'default' will be used if it exists. (default "default")
       --auth-provider-type string      Provider type choices: (azid)
       --client-id string               OAuth2 client-id to use for authenticating to Keyfactor Command.
@@ -47,6 +48,7 @@ kfutil upgrade [flags]
       --offline                        Will not attempt to connect to GitHub for latest release information and resources.
       --password string                Password to use for authenticating to Keyfactor Command. WARNING: Remember to delete your console history if providing kfcPassword here in plain text.
       --profile string                 Use a specific profile from your config file. If not specified the config named 'default' will be used if it exists.
+      --scopes string                  Comma-separated list of OAuth2 scopes to request when authenticating via a third-party IdP (e.g. Entra ID: api://<app-id-uri>/.default).
       --skip-tls-verify                Disable TLS verification for API requests to Keyfactor Command.
       --token-url string               OAuth2 token endpoint full URL to use for authenticating to Keyfactor Command.
       --username string                Username to use for authenticating to Keyfactor Command.

--- a/docs/kfutil_version.md
+++ b/docs/kfutil_version.md
@@ -20,6 +20,7 @@ kfutil version [flags]
 
 ```
       --api-path string                API Path to use for authenticating to Keyfactor Command. (default is KeyfactorAPI) (default "KeyfactorAPI")
+      --audience string                OAuth2 audience to request when authenticating to Keyfactor Command. Not used by all IdPs (e.g. leave unset for Entra ID).
       --auth-provider-profile string   The profile to use defined in the securely stored config. If not specified the config named 'default' will be used if it exists. (default "default")
       --auth-provider-type string      Provider type choices: (azid)
       --client-id string               OAuth2 client-id to use for authenticating to Keyfactor Command.
@@ -34,6 +35,7 @@ kfutil version [flags]
       --offline                        Will not attempt to connect to GitHub for latest release information and resources.
       --password string                Password to use for authenticating to Keyfactor Command. WARNING: Remember to delete your console history if providing kfcPassword here in plain text.
       --profile string                 Use a specific profile from your config file. If not specified the config named 'default' will be used if it exists.
+      --scopes string                  Comma-separated list of OAuth2 scopes to request when authenticating via a third-party IdP (e.g. Entra ID: api://<app-id-uri>/.default).
       --skip-tls-verify                Disable TLS verification for API requests to Keyfactor Command.
       --token-url string               OAuth2 token endpoint full URL to use for authenticating to Keyfactor Command.
       --username string                Username to use for authenticating to Keyfactor Command.

--- a/readme_source.md
+++ b/readme_source.md
@@ -65,10 +65,44 @@ Currently `Basic Authentication` via `Active Directory` is the *ONLY* supported 
 | KEYFACTOR_AUTH_CLIENT_ID     | Keyfactor Auth Client ID                                                                                                        |          |
 | KEYFACTOR_AUTH_CLIENT_SECRET | Keyfactor Auth Client Secret                                                                                                    |          |
 | KEYFACTOR_AUTH_TOKEN_URL     | URL to request an access token from Keyfactor Auth                                                                              |          |
-| KEYFACTOR_AUTH_SCOPES        | Scopes to request when authenticating to Keyfactor Command API. Each scope MUST be separated by `,`                             | `openid` |
-| KEYFACTOR_AUTH_AUDIENCE      | Audience to request when authenticating to Keyfactor Command API                                                                |          |
+| KEYFACTOR_AUTH_SCOPES        | Scopes to request when authenticating to Keyfactor Command API. Multiple scopes MUST be separated by `,` (comma)                | _(none)_ |
+| KEYFACTOR_AUTH_AUDIENCE      | Audience to request when authenticating to Keyfactor Command API. Sent as the `audience` form parameter. Leave unset for Microsoft Entra ID (see below) |          |
 | KEYFACTOR_AUTH_ACCESS_TOKEN  | Access token to use to authenticate to Keyfactor Command API. This can be supplied directly or generated via client credentials |          |
 | KEYFACTOR_AUTH_CA_CERT       | Either a file path or PEM encoded string to a CA certificate to use when connecting to Keyfactor Auth                           |          |
+
+`kfutil` supports two oAuth2 grant types:
+
+- **Client Credentials** — `kfutil` exchanges a `client_id` and `client_secret` at the `token_url` for an
+  access token. This is the most common configuration.
+- **Static Access Token** — you supply a previously obtained access token directly via `KEYFACTOR_AUTH_ACCESS_TOKEN`.
+
+The interactive authorization-code / PKCE grant is **not** supported.
+
+#### Third-party IdP (Microsoft Entra ID / Azure AD)
+
+`kfutil` is not limited to the Keyfactor-hosted Keycloak IdP. Because the token endpoint (`token_url`) and
+`scopes` are fully configurable, you can authenticate against any OAuth2 IdP that Keyfactor Command trusts,
+including **Microsoft Entra ID** (formerly Azure AD).
+
+The Entra-side setup (registering the Command API application, exposing an API / Application ID URI, and
+granting the calling application permission to it) is documented in the Keyfactor Command / Entra SSO
+documentation and is a prerequisite for the steps below. Once that is in place, configure `kfutil` as follows:
+
+- **`token_url`** must point at the Entra v2.0 token endpoint for your tenant:
+  `https://login.microsoftonline.com/<tenant-id>/oauth2/v2.0/token`
+- **`client_id`** / **`client_secret`** are the Entra app registration's *Application (client) ID* and a
+  *client secret* generated for it.
+- **`scopes`** is **mandatory** for Entra and must be `api://<command-app-id-uri>/.default`. `kfutil` does not
+  send any scope by default, so a request with no scope configured will be rejected by Entra.
+  When using the `KEYFACTOR_AUTH_SCOPES` environment variable, supply exactly **one** scope with **no commas**
+  (the value is split on `,`).
+- **`audience`** must be **left unset** for Entra. Entra does not accept an `audience` form parameter; the
+  target resource is encoded inside the `.default` scope instead.
+
+> **Scope vs. audience — the key distinction:** Some IdPs (such as Keycloak) identify the target resource via
+> an `audience` parameter. Entra ID does **not**; it derives the resource from the requested scope
+> (`api://<command-app-id-uri>/.default`). If you set `audience` when authenticating against Entra, the token
+> request will fail. Use `scopes` for Entra and leave `audience` empty.
 
 ### kfutil specific
 
@@ -112,6 +146,19 @@ This is the minimum required configuration to authenticate to Keyfactor Command 
 ```bash
 export KEYFACTOR_HOSTNAME="<mykeyfactorhost.mydomain.com>"
 export KEYFACTOR_AUTH_ACCESS_TOKEN="<my-access-token>"
+```
+
+#### oAuth Client Credentials with Microsoft Entra ID (Azure AD)
+
+This authenticates to Keyfactor Command using an Entra ID app registration. Note the Entra v2.0 `token_url`,
+the mandatory `.default` scope, and that `KEYFACTOR_AUTH_AUDIENCE` is intentionally **not** set.
+```bash
+export KEYFACTOR_HOSTNAME="<mykeyfactorhost.mydomain.com>"
+export KEYFACTOR_AUTH_CLIENT_ID="<entra-app-client-id>"
+export KEYFACTOR_AUTH_CLIENT_SECRET="<entra-client-secret>"
+export KEYFACTOR_AUTH_TOKEN_URL="https://login.microsoftonline.com/<tenant-id>/oauth2/v2.0/token"
+export KEYFACTOR_AUTH_SCOPES="api://<command-app-id-uri>/.default"
+# Do NOT set KEYFACTOR_AUTH_AUDIENCE for Entra ID
 ```
 
 #### Additional variables
@@ -158,6 +205,20 @@ This is the minimum required configuration to authenticate to Keyfactor Command 
 ```powershell
 $env:KEYFACTOR_HOSTNAME = "<mykeyfactorhost.mydomain.com>"
 $env:KEYFACTOR_AUTH_ACCESS_TOKEN = "<my-access-token>"
+```
+
+#### oAuth Client Credentials with Microsoft Entra ID (Azure AD)
+
+This authenticates to Keyfactor Command using an Entra ID app registration. Note the Entra v2.0 token URL,
+the mandatory `.default` scope, and that `KEYFACTOR_AUTH_AUDIENCE` is intentionally **not** set.
+
+```powershell
+$env:KEYFACTOR_HOSTNAME = "<mykeyfactorhost.mydomain.com>"
+$env:KEYFACTOR_AUTH_CLIENT_ID = "<entra-app-client-id>"
+$env:KEYFACTOR_AUTH_CLIENT_SECRET = "<entra-client-secret>"
+$env:KEYFACTOR_AUTH_TOKEN_URL = "https://login.microsoftonline.com/<tenant-id>/oauth2/v2.0/token"
+$env:KEYFACTOR_AUTH_SCOPES = "api://<command-app-id-uri>/.default"
+# Do NOT set KEYFACTOR_AUTH_AUDIENCE for Entra ID
 ```
 
 #### Additional variables:


### PR DESCRIPTION
## Summary

Issue #234 asked for documentation on authenticating `kfutil` against Keyfactor Command using OAuth, specifically with a third-party IdP such as **Microsoft Entra ID (Azure AD)**. The code already supported arbitrary token URLs and custom scopes, but nothing documented how to configure it, and there were conceptual traps (notably the scope-vs-audience distinction). This PR adds that documentation, fixes two small related correctness issues, and **wires up the previously non-functional auth CLI flags**.

## What changed

- **Docs — Third-party IdP / Entra ID section** added to `README.md` / `readme_source.md` and `docs/auth_providers.md`:
  - Entra v2.0 token endpoint (`https://login.microsoftonline.com/<tenant-id>/oauth2/v2.0/token`).
  - `client_id` / `client_secret` map to the Entra app registration's Application (client) ID and secret.
  - `scopes` is mandatory and must be `api://<command-app-id-uri>/.default` (kfutil sends no scope by default).
  - `audience` must be left unset for Entra, with a "scope vs. audience" explanation of why.
  - Note that `KEYFACTOR_AUTH_SCOPES` is comma-split, so supply exactly one Entra scope with no commas.
  - Ready-to-use JSON config profile and bash/PowerShell env-var examples.
  - Note that the Command-side app-registration / API-permissions setup lives in the Command / Entra SSO docs.
  - Clarified the two supported grant types (client credentials + static access token; no auth-code/PKCE).
- **Correction — `openid` default scope claim**: the README stated `KEYFACTOR_AUTH_SCOPES` defaults to `openid`. The auth client sends no scope by default; the table now reflects `_(none)_`.
- **Bug fix — `--token-url` flag binding** (`cmd/root.go`): the flag was bound to `&kfcClientId` (copy-paste bug), clobbering the client-id variable. It now binds to the correct `&kfcTokenUrl` variable.
- **Feature — auth CLI flags are now functional** (`cmd/root.go`): the persistent auth flags (`--client-id`, `--client-secret`, `--token-url`, `--hostname`, `--username`, `--password`, `--domain`, `--api-path`) were declared but never consumed by the auth flow — only referenced in log statements. They are now wired into `getServerConfigFromEnv()`, the single chokepoint used by both the legacy and SDK clients.
  - **Precedence:** an explicitly-provided flag takes precedence over the corresponding environment variable. This uses pflag `Changed()` (rather than a non-empty check) so the non-empty `--api-path` default no longer silently clobbers a set `KEYFACTOR_API_PATH`.
  - **New flags:** added `--scopes` (comma-separated, matching `KEYFACTOR_AUTH_SCOPES`) and `--audience` for third-party IdP (e.g. Entra ID) client-credentials auth.

## Testing

- `go build ./...` — passes.
- `go vet ./...` — no new issues (pre-existing warning in `cmd/helpers.go`, unrelated to this change).
- **Flag wiring verified end-to-end** with `--debug`: running an authenticating command with `--client-id/--client-secret/--token-url/--hostname/--scopes` now enters the OAuth path and attempts a token request against the flag-provided token URL (previously the flags did nothing). Confirmed the flag values (`clientId`, `tokenUrl`, `scopes`) flow into the OAuth config.
- `go run main.go makedocs` — ran; regenerated cobra command docs now include the new `--scopes` / `--audience` inherited flags. The generator also re-emits store-type/PAM docs from external Command data (unrelated drift); those were intentionally not committed. `README.md` is produced from `readme_source.md` by an external Keyfactor bootstrap template that is not runnable locally, so the equivalent edits were mirrored into `README.md` by hand to keep the two in sync.

> **Reviewer note:** end-to-end OAuth/basic login against a live Keyfactor Command instance was not exercised (no lab available in this environment). The flag→config wiring is verified; a functional login against a real Command + Entra tenant is worth a final check before merge.

Closes #234
